### PR TITLE
Modify Verifier.cpp so that Freeze accept only integer type & Add llvm-as error message 

### DIFF
--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -5832,6 +5832,9 @@ bool LLParser::ParseFreeze(Instruction *&Inst, PerFunctionState &PFS) {
   if (ParseTypeAndValue(Op, Loc, PFS))
     return true;
 
+  if (!Op->getType()->isIntegerTy())
+    return Error(Loc,"cannot freeze non-integer type");
+
   Inst = new FreezeInst(Op, "");
   return false;
 }

--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -3533,8 +3533,8 @@ void Verifier::visitCleanupReturnInst(CleanupReturnInst &CRI) {
 }
 
 void Verifier::visitFreezeInst(FreezeInst &FI) {
-  Assert(!FI.getOperand(0)->getType()->isVoidTy(),
-         "Cannot freeze void type!", &FI);
+  Assert(FI.getOperand(0)->getType()->isIntegerTy(),
+         "Cannot freeze non-integer type!", &FI);
 
   visitInstruction(FI);
 }


### PR DESCRIPTION
I modified Verifier.cpp so that Freeze would accept only integer type.
https://github.com/snu-sf/llvm-freeze/commit/8b8db201b09b1db501a89917a685021f25e1f0e6#commitcomment-18404335

Also I modified LLParser.cpp so that llvm-as print typing error message like below : 

```
../../llvm-freeze-base-build/bin/llvm-as: ./test.ll:4:16: error: cannot freeze non-integer type
  %z2 = freeze float %z                                                                        
               ^                                                                               
```

Previously llvm-as showed error message like following : 

```
../../llvm-freeze-base-build/bin/llvm-as: assembly parsed, but does not verify as correct!
Cannot freeze void type!                                                                  
  %z2 = freeze float %z                                                                   
Cannot freeze void type!                                                                  
  %w2 = freeze i32* %w                                                                    
Cannot freeze void type!                                                                  
  %u2 = freeze [4 x i8] %u                                                                
Cannot freeze void type!                                                                  
  %v2 = freeze <4 x i8> %v                                                               
```

P.S : These commits should be merged to `conservative` branch as well. If this PR is reviewed, I'll merge these commits into `conservative` branch.
