### PR TITLE
Add C functions in llvm-c/Core.h , Add IRBuilder::CreateFreeze

### DIFF
--- a/include/llvm-c/Core.h
+++ b/include/llvm-c/Core.h
@@ -1254,6 +1254,7 @@ LLVMTypeRef LLVMX86MMXType(void);
       macro(SelectInst)                     \
       macro(ShuffleVectorInst)              \
       macro(StoreInst)                      \
+      macro(FreezeInst)                     \
       macro(TerminatorInst)                 \
         macro(BranchInst)                   \
         macro(IndirectBrInst)               \
@@ -3095,6 +3096,8 @@ LLVMValueRef LLVMBuildExtractValue(LLVMBuilderRef, LLVMValueRef AggVal,
 LLVMValueRef LLVMBuildInsertValue(LLVMBuilderRef, LLVMValueRef AggVal,
                                   LLVMValueRef EltVal, unsigned Index,
                                   const char *Name);
+LLVMValueRef LLVMBuildFreeze(LLVMBuilderRef, LLVMValueRef Val,
+                                   const char *Name);
 
 LLVMValueRef LLVMBuildIsNull(LLVMBuilderRef, LLVMValueRef Val,
                              const char *Name);

--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -1669,6 +1669,10 @@ public:
     return Insert(InsertValueInst::Create(Agg, Val, Idxs), Name);
   }
 
+  Value *CreateFreeze(Value *V, const Twine &Name = "") {
+    return Insert(new FreezeInst(V), Name);
+  }
+
   LandingPadInst *CreateLandingPad(Type *Ty, unsigned NumClauses,
                                    const Twine &Name = "") {
     return Insert(LandingPadInst::Create(Ty, NumClauses), Name);

--- a/lib/IR/Core.cpp
+++ b/lib/IR/Core.cpp
@@ -3018,6 +3018,10 @@ LLVMValueRef LLVMBuildInsertValue(LLVMBuilderRef B, LLVMValueRef AggVal,
                                            Index, Name));
 }
 
+LLVMValueRef LLVMBuildFreeze(LLVMBuilderRef B, LLVMValueRef Val, const char *Name) {
+  return wrap(unwrap(B)->CreateFreeze(unwrap(Val), Name));
+}
+
 LLVMValueRef LLVMBuildIsNull(LLVMBuilderRef B, LLVMValueRef Val,
                              const char *Name) {
   return wrap(unwrap(B)->CreateIsNull(unwrap(Val), Name));


### PR DESCRIPTION
I implemented Freeze-related functions in LLVM-C(Core.h / Core.cpp), and `CreateFreeze()` in IRBuilder class.

To check newly added functions, I ran a sample C code which generates sample IR file & checked that it correctly creates a IR function with a freeze instruction inside. 

[test.c.zip](https://github.com/snu-sf/llvm-freeze/files/404932/test.c.zip)

Note that `IRBuilder::CreateFreeze()` is called from `LLVMBuildFreeze()` function.

P.S : These commits should be merged to `conservative` branch as well. If this PR is reviewed, I'll merge these commits into `conservative` branch as well.
