### PR TITLE
Add Freeze constant expression (No constant folding)

### DIFF
--- a/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/include/llvm/Bitcode/LLVMBitCodes.h
@@ -286,8 +286,9 @@ enum ConstantsCodes {
   CST_CODE_CE_INBOUNDS_GEP = 20, // INBOUNDS_GEP:  [n x operands]
   CST_CODE_BLOCKADDRESS = 21,    // CST_CODE_BLOCKADDRESS [fnty, fnval, bb#]
   CST_CODE_DATA = 22,            // DATA:          [n x elements]
-  CST_CODE_INLINEASM = 23        // INLINEASM:     [sideeffect|alignstack|
+  CST_CODE_INLINEASM = 23,       // INLINEASM:     [sideeffect|alignstack|
                                  //                 asmdialect,asmstr,conststr]
+  CST_CODE_CE_FREEZE = 24        // FREEZE:        [opty, opval]
 };
 
 /// CastOpcodes - These are values used in the bitcode files to encode which

--- a/include/llvm/IR/ConstantFolder.h
+++ b/include/llvm/IR/ConstantFolder.h
@@ -215,6 +215,10 @@ public:
     return ConstantExpr::getSelect(C, True, False);
   }
 
+  Constant *CreateFreeze(Constant *C) const {
+    return ConstantExpr::getFreeze(C);
+  }
+
   Constant *CreateExtractElement(Constant *Vec, Constant *Idx) const {
     return ConstantExpr::getExtractElement(Vec, Idx);
   }

--- a/include/llvm/IR/Constants.h
+++ b/include/llvm/IR/Constants.h
@@ -916,6 +916,7 @@ public:
                               bool OnlyIfReduced = false);
   static Constant *getAddrSpaceCast(Constant *C, Type *Ty,
                                     bool OnlyIfReduced = false);
+  static Constant *getFreeze(Constant *C);
 
   static Constant *getNSWNeg(Constant *C) { return getNeg(C, false, true); }
   static Constant *getNUWNeg(Constant *C) { return getNeg(C, true, false); }

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -4947,6 +4947,15 @@ public:
     BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
   );
 
+  /// isValidOperand - Return true if a freeze instruction can be
+  /// formed with the specified operand.
+  static bool isValidOperand(const Value *S);
+
+  static FreezeInst *Create(Value *S, const Twine &NameStr = "",
+                            Instruction *InsertBefore = nullptr) {
+    return new FreezeInst(S, NameStr, InsertBefore);
+  }
+
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static inline bool classof(const Instruction *I) {
     return I->getOpcode() == Freeze;

--- a/lib/Analysis/ConstantFolding.cpp
+++ b/lib/Analysis/ConstantFolding.cpp
@@ -995,8 +995,11 @@ Constant *llvm::ConstantFoldInstruction(Instruction *I, const DataLayout &DL,
   for (User::op_iterator i = I->op_begin(), e = I->op_end(); i != e; ++i) {
     Constant *Op = cast<Constant>(*i);
     // Fold the Instruction's operands.
-    if (ConstantExpr *NewCE = dyn_cast<ConstantExpr>(Op))
-      Op = ConstantFoldConstantExpression(NewCE, DL, TLI);
+    if (ConstantExpr *NewCE = dyn_cast<ConstantExpr>(Op)) {
+      Constant *NewOp = ConstantFoldConstantExpression(NewCE, DL, TLI);
+      if (NewOp != nullptr)
+        Op = NewOp;
+    }
 
     Ops.push_back(Op);
   }

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -2945,6 +2945,20 @@ bool LLParser::ParseValID(ValID &ID, PerFunctionState *PFS) {
     ID.Kind = ValID::t_Constant;
     return false;
   }
+  case lltok::kw_freeze: {
+    Constant *SrcVal;
+    Lex.Lex();
+    if (ParseToken(lltok::lparen, "expected '(' after constantexpr freeze") ||
+        ParseGlobalTypeAndValue(SrcVal) ||
+        ParseToken(lltok::rparen, "expected ')' at end of constantexpr freeze"))
+      return true;
+    if (!FreezeInst::isValidOperand(SrcVal))
+      return Error(ID.Loc, "invalid freeze operand type '" + 
+                   getTypeString(SrcVal->getType()));
+    ID.ConstantVal = ConstantExpr::getFreeze(SrcVal);
+    ID.Kind = ValID::t_Constant;
+    return false;
+  }
   case lltok::kw_extractvalue: {
     Lex.Lex();
     Constant *Val;

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -3206,6 +3206,17 @@ std::error_code BitcodeReader::parseConstants() {
         V = ConstantExpr::getICmp(Record[3], Op0, Op1);
       break;
     }
+    case bitc::CST_CODE_CE_FREEZE: {    // CE_FREEZE: [opty, opval]
+      if (Record.size() != 2)
+        return error("Invalid record");
+      Type *OpTy = getTypeByID(Record[0]);
+      if (!OpTy)
+        return error("Invalid record");
+      Constant *Op0 = ValueList.getConstantFwdRef(Record[1], OpTy);
+
+      V = ConstantExpr::getFreeze(Op0);
+      break;
+    }
     // This maintains backward compatibility, pre-asm dialect keywords.
     // FIXME: Remove with the 4.0 release.
     case bitc::CST_CODE_INLINEASM_OLD: {

--- a/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -2136,6 +2136,10 @@ void ModuleBitcodeWriter::writeConstants(unsigned FirstVal, unsigned LastVal,
           Record.push_back(VE.getTypeID(C->getOperand(0)->getType()));
           Record.push_back(VE.getValueID(C->getOperand(0)));
           AbbrevToUse = CONSTANTS_CE_CAST_Abbrev;
+        } else if (CE->getOpcode() == Instruction::Freeze) {
+          Code = bitc::CST_CODE_CE_FREEZE;
+          Record.push_back(VE.getTypeID(C->getOperand(0)->getType()));
+          Record.push_back(VE.getValueID(C->getOperand(0)));
         } else {
           assert(CE->getNumOperands() == 2 && "Unknown constant expr!");
           Code = bitc::CST_CODE_CE_BINOP;

--- a/lib/IR/ConstantFold.cpp
+++ b/lib/IR/ConstantFold.cpp
@@ -2267,3 +2267,8 @@ Constant *llvm::ConstantFoldGetElementPtr(Type *Ty, Constant *C,
                                           ArrayRef<Value *> Idxs) {
   return ConstantFoldGetElementPtrImpl(Ty, C, inBounds, Idxs);
 }
+
+Constant *llvm::ConstantFoldFreezeInstruction(Constant *C) {
+  // At this point we do not fold freeze instruction..
+  return nullptr; 
+}

--- a/lib/IR/ConstantFold.h
+++ b/lib/IR/ConstantFold.h
@@ -50,6 +50,7 @@ template <typename T> class ArrayRef;
                                       ArrayRef<Constant *> Idxs);
   Constant *ConstantFoldGetElementPtr(Type *Ty, Constant *C, bool inBounds,
                                       ArrayRef<Value *> Idxs);
+  Constant *ConstantFoldFreezeInstruction(Constant *C);
 } // End llvm namespace
 
 #endif

--- a/lib/IR/ConstantsContext.h
+++ b/lib/IR/ConstantsContext.h
@@ -534,6 +534,8 @@ struct ConstantExprKeyType {
     case Instruction::FCmp:
       return new CompareConstantExpr(Ty, Instruction::FCmp, SubclassData,
                                      Ops[0], Ops[1]);
+    case Instruction::Freeze:
+      return new UnaryConstantExpr(Opcode, Ops[0], Ty);
     }
   }
 };

--- a/lib/IR/Instructions.cpp
+++ b/lib/IR/Instructions.cpp
@@ -3861,13 +3861,19 @@ void IndirectBrInst::setSuccessorV(unsigned idx, BasicBlock *B) {
 FreezeInst::FreezeInst(Value *S,
                        const Twine &Name, Instruction *InsertBefore)
     : UnaryInstruction(S->getType(), Freeze, S, InsertBefore) {
+  assert(isValidOperand(S) && "Invalid freeze instruction operand!");
   setName(Name);
 }
 
 FreezeInst::FreezeInst(Value *S,
                        const Twine &Name, BasicBlock *InsertAtEnd)
     : UnaryInstruction(S->getType(), Freeze, S, InsertAtEnd) {
+  assert(isValidOperand(S) && "Invalid freeze instruction operand!");
   setName(Name);
+}
+
+bool FreezeInst::isValidOperand(const Value *S) {
+  return S->getType()->isIntegerTy();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
I added `freeze` constant expression.

I tested with two following IR codes

case 1 : 

```
define i32 @foo(i32 %x) {                            
  %z = freeze i32 add (i32 1, i32 2)                 
  %t = add i32 add (i32 3, i32 4), freeze (i32 undef)
  ret i32 %t                                         
}                                                    
```

case 1 (llvm-dis after llvm-as) : 

```
define i32 @foo(i32 %x) {           
  %z = freeze i32 3                 
  %t = add i32 7, freeze (i32 undef)
  ret i32 %t                        
}                                   
```

case 2 : 

```
define i32 @foo(i32 %x) {                                            
  %z = freeze i32 add (i32 1, i32 2)                                 
  %t = add i32 add (i32 3, i32 freeze (i32 undef)), freeze (i32 undef)
  ret i32 %t                                                         
}                                                                    
```

case 2(llvm-dis after llvm-as) : 

```
define i32 @foo(i32 %x) {                                             
  %z = freeze i32 3                                                   
  %t = add i32 add (i32 freeze (i32 undef), i32 3), freeze (i32 undef)
  ret i32 %t                                                          
}                                                                     
```

Note that arguments in `add` constant expressions are folded. It is not related to the modifications done in this PR ; `BitcodeReader.cpp` calls `ConstantExpr::getXX` functions to create constant expression instances, and `ConstantExpr::getXX` calls `ConstantFoldXXXInstruction` which tries to fold constant expressions.

In commit https://github.com/snu-sf/llvm-freeze/commit/cf96fe9ffee95bd50e9d545d582948bbda090a44,    I modified `ConstantFoldInstruction()` in `ConstantFolding.cpp` so that it may not fail when one if its arguments (`NewCE`) is `ConstantExpr` and `ConstantFoldConstantExpression(NewCE)` returns `nullptr`. I thought this was a bug, and I checked whether it was fixed in the main LLVM repo, but the original `ConstantFolding.cpp` changed a lot.

This PR must be merged to `conservative` branch as well.
