### PR TITLE
Add freeze in select(c, bop(x,y), bop(x,z)) -> bop(x,(select(c,y,z)) optimization

### DIFF
--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -1690,6 +1690,38 @@ public:
                         Name);
   }
 
+  /// \brief If \p Arg is guaranteed not to be undef, return \p Arg.
+  /// Otherwise, insert a freeze instruction at the definition of \p Arg and return 
+  /// the new value
+  Value *CreateFreezeAtDef(Value *Arg, Function *F, const Twine &Name = "") {
+    if (FreezeInst::isGuaranteedNotToBeUndef(Arg))
+      return Arg;
+    
+    if (Instruction *I = dyn_cast<Instruction>(Arg)) {
+      FreezeInst *FI = new FreezeInst(I, Name);
+      BasicBlock *BB = I->getParent();
+      if (isa<PHINode>(I)) {
+        BB->getInstList().insert(BB->getFirstInsertionPt(), FI);
+      } else {
+        FI->insertAfter(I);
+      }
+      I->replaceAllUsesWith(FI);
+      FI->replaceUsesOfWith(FI, I);
+      return FI;
+    } else if (isa<Constant>(Arg) || isa<Argument>(Arg)) {
+      BasicBlock &Entry = F->getEntryBlock();
+      FreezeInst *FI = new FreezeInst(Arg, Name, &*Entry.getFirstInsertionPt());
+      
+      Arg->replaceAllUsesWith(FI);
+      FI->replaceUsesOfWith(FI, Arg);
+      return FI;
+    }
+    
+    assert((isa<PHINode>(Arg) || isa<Constant>(Arg) || isa<Argument>(Arg)) &&
+        "Cannot freeze the value");
+    return nullptr;
+  }
+
   /// \brief Return the i64 difference between two pointer values, dividing out
   /// the size of the pointed-to objects.
   ///

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -204,11 +204,17 @@ Instruction *InstCombiner::FoldSelectOpOp(SelectInst &SI, Instruction *TI,
   // X = udiv A, B           | 
   // Y = udiv A, C           | t' = select undef, B, C (which is undef)
   // Z = select undef, X, Y  | Z = udiv A, t' (which is UB)
-  // NOTE : We don't have to freeze the value if the opcode is neither 
-  // div nor rem.
-  Value *FreezedValue = Builder->CreateFreezeAtDef(SI.getCondition(),
+  Value *Cond = SI.getCondition();
+  switch (TI->getOpcode()) {
+  default : break;
+  case Instruction::UDiv:
+  case Instruction::URem:
+  case Instruction::SDiv:
+  case Instruction::SRem:
+    Cond = Builder->CreateFreezeAtDef(SI.getCondition(),
                                        SI.getParent()->getParent());
-  Value *NewSI = Builder->CreateSelect(FreezedValue, OtherOpT,
+  }
+  Value *NewSI = Builder->CreateSelect(Cond, OtherOpT,
                                        OtherOpF, SI.getName()+".v");
 
   if (BinaryOperator *BO = dyn_cast<BinaryOperator>(TI)) {

--- a/lib/Transforms/Scalar/LoopUnswitch.cpp
+++ b/lib/Transforms/Scalar/LoopUnswitch.cpp
@@ -809,38 +809,6 @@ void LoopUnswitch::EmitPreheaderBranchOnCondition(Value *LIC, Constant *Val,
   SplitCriticalEdge(BI, 1, Options);
 }
 
-// Freeze the hoisted branch condition
-void FreezeCond(Value *&cond, BasicBlock *BB) {
-  assert(!isa<Constant>(cond) && "Constants are not unswitched");
-  // Check whether freezing is not required
-  if (FreezeInst::isGuaranteedNotToBeUndef(cond))
-    return;
-  
-  // Insert freeze when cond is an instruction.
-  if (Instruction *condInst = dyn_cast<Instruction>(cond)) {
-    FreezeInst *FI = new FreezeInst(condInst, condInst->getName() + ".fr");
-    BasicBlock *BB = condInst->getParent();
-    if (isa<PHINode>(condInst))
-      BB->getInstList().insert(BB->getFirstInsertionPt(), FI);
-    else
-      FI->insertAfter(condInst);
-
-    condInst->replaceAllUsesWith(FI);
-    FI->replaceUsesOfWith(FI, condInst);
-    
-    cond = FI;
-  } else if (Argument *condArg = dyn_cast<Argument>(cond)) {
-    BasicBlock &Entry = BB->getParent()->getEntryBlock();
-    FreezeInst *FI = new FreezeInst(condArg, condArg->getName() + ".fr", &*Entry.getFirstInsertionPt());
-
-    condArg->replaceAllUsesWith(FI);
-    FI->replaceUsesOfWith(FI, condArg);
-    
-    cond = FI;
-  }
-
-}
-
 /// Given a loop that has a trivial unswitchable condition in it (a cond branch
 /// from its header block to its latch block, where the path through the loop
 /// that doesn't execute its body has no side-effects), unswitch it. This
@@ -872,7 +840,8 @@ void LoopUnswitch::UnswitchTrivialCondition(Loop *L, Value *Cond, Constant *Val,
   BasicBlock *NewExit = SplitBlock(ExitBlock, &ExitBlock->front(), DT, LI);
 
   // Freeze
-  FreezeCond(Cond, loopPreheader);
+  IRBuilder<> Builder(ExitBlock);
+  Builder.CreateFreezeAtDef(Cond, ExitBlock->getParent(), Cond->getName() + ".fr");
 
   // Okay, now we have a position to branch from and a position to branch to,
   // insert the new conditional branch.
@@ -1179,7 +1148,8 @@ void LoopUnswitch::UnswitchNontrivialCondition(Value *LIC, Constant *Val,
   // Emit the new branch that selects between the two versions of this loop.
 
   // Freeze
-  FreezeCond(LIC, loopPreheader);
+  IRBuilder<> Builder(loopPreheader);
+  Builder.CreateFreezeAtDef(LIC, loopPreheader->getParent(), LIC->getName() + ".fr");
   
   EmitPreheaderBranchOnCondition(LIC, Val, NewBlocks[0], LoopBlocks[0], OldBR,
                                  TI);


### PR DESCRIPTION
I added freeze instruction in `select(c, bop(x,y), bop(x,z))` -> `bop(x,(select(c,y,z))` optimization.

I moved `FreezeCond` function from LoopUnswitch.cpp to IRBuilder.h.
