### PR TITLE
PR Equiv. to #18, but Target is `conservative` branch

### DIFF
--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -5832,6 +5832,9 @@ bool LLParser::ParseFreeze(Instruction *&Inst, PerFunctionState &PFS) {
   if (ParseTypeAndValue(Op, Loc, PFS))
     return true;
 
+  if (!Op->getType()->isIntegerTy())
+    return Error(Loc,"cannot freeze non-integer type");
+
   Inst = new FreezeInst(Op, "");
   return false;
 }

--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -3533,8 +3533,8 @@ void Verifier::visitCleanupReturnInst(CleanupReturnInst &CRI) {
 }
 
 void Verifier::visitFreezeInst(FreezeInst &FI) {
-  Assert(!FI.getOperand(0)->getType()->isVoidTy(),
-         "Cannot freeze void type!", &FI);
+  Assert(FI.getOperand(0)->getType()->isIntegerTy(),
+         "Cannot freeze non-integer type!", &FI);
 
   visitInstruction(FI);
 }


### PR DESCRIPTION
Contents : "Modify Verifier.cpp so that Freeze accepts only integer type & Add type checking error message in LLParser.cpp"

As I said in #18, I'll merge this PR by myself.
