### PR TITLE
Let IRBuilder::CreateFreezeAtDef does not accept constant, Fix loop-unswitch code in #22, Fix llvm-tests

### DIFF
--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -1700,7 +1700,9 @@ public:
   Value *CreateFreezeAtDef(Value *Arg, Function *F, const Twine &Name = "") {
     if (FreezeInst::isGuaranteedNotToBeUndef(Arg))
       return Arg;
-    
+
+    assert (!isa<Constant>(Arg) && "Constant has no def");
+
     if (Instruction *I = dyn_cast<Instruction>(Arg)) {
       FreezeInst *FI = new FreezeInst(I, Name);
       BasicBlock *BB = I->getParent();
@@ -1720,7 +1722,7 @@ public:
       FI->replaceUsesOfWith(FI, Arg);
       return FI;
     }
-    
+
     assert((isa<PHINode>(Arg) || isa<Constant>(Arg) || isa<Argument>(Arg)) &&
         "Cannot freeze the value");
     return nullptr;

--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -1700,7 +1700,9 @@ public:
   Value *CreateFreezeAtDef(Value *Arg, Function *F, const Twine &Name = "") {
     if (FreezeInst::isGuaranteedNotToBeUndef(Arg))
       return Arg;
-    
+
+    assert (!isa<Constant>(Arg) && "Constant has no def");
+
     if (Instruction *I = dyn_cast<Instruction>(Arg)) {
       FreezeInst *FI = new FreezeInst(I, Name);
       BasicBlock *BB = I->getParent();
@@ -1712,7 +1714,7 @@ public:
       I->replaceAllUsesWith(FI);
       FI->replaceUsesOfWith(FI, I);
       return FI;
-    } else if (isa<Constant>(Arg) || isa<Argument>(Arg)) {
+    } else if (isa<Argument>(Arg)) {
       BasicBlock &Entry = F->getEntryBlock();
       FreezeInst *FI = new FreezeInst(Arg, Name, &*Entry.getFirstInsertionPt());
       
@@ -1720,8 +1722,8 @@ public:
       FI->replaceUsesOfWith(FI, Arg);
       return FI;
     }
-    
-    assert((isa<PHINode>(Arg) || isa<Constant>(Arg) || isa<Argument>(Arg)) &&
+
+    assert((isa<Instruction>(Arg) || isa<Argument>(Arg)) &&
         "Cannot freeze the value");
     return nullptr;
   }

--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -1714,7 +1714,8 @@ public:
       I->replaceAllUsesWith(FI);
       FI->replaceUsesOfWith(FI, I);
       return FI;
-    } else if (isa<Argument>(Arg)) {
+    } else {
+      assert(isa<Argument>(Arg) && "Cannot freeze the value");
       BasicBlock &Entry = F->getEntryBlock();
       FreezeInst *FI = new FreezeInst(Arg, Name, &*Entry.getFirstInsertionPt());
       
@@ -1723,8 +1724,6 @@ public:
       return FI;
     }
 
-    assert((isa<Instruction>(Arg) || isa<Argument>(Arg)) &&
-        "Cannot freeze the value");
     return nullptr;
   }
 

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -211,8 +211,15 @@ Instruction *InstCombiner::FoldSelectOpOp(SelectInst &SI, Instruction *TI,
   case Instruction::URem:
   case Instruction::SDiv:
   case Instruction::SRem:
-    Cond = Builder->CreateFreezeAtDef(SI.getCondition(),
-                                       SI.getParent()->getParent());
+    if (!isa<Constant>(SI.getCondition()))
+      // Create Freeze at the definition of condition value, and
+      // replace all uses of SI.getCondition() with the new freeze instruction.
+      Cond = Builder->CreateFreezeAtDef(Cond,
+                                       SI.getParent()->getParent(),
+                                       Cond->getName() + ".fr");
+    else
+      Cond = Builder->CreateFreeze(Cond, 
+                                   Cond->getName() + ".fr");
   }
   Value *NewSI = Builder->CreateSelect(Cond, OtherOpT,
                                        OtherOpF, SI.getName()+".v");

--- a/lib/Transforms/Scalar/LoopUnswitch.cpp
+++ b/lib/Transforms/Scalar/LoopUnswitch.cpp
@@ -841,7 +841,7 @@ void LoopUnswitch::UnswitchTrivialCondition(Loop *L, Value *Cond, Constant *Val,
 
   // Freeze
   IRBuilder<> Builder(ExitBlock);
-  Builder.CreateFreezeAtDef(Cond, ExitBlock->getParent(), Cond->getName() + ".fr");
+  Cond = Builder.CreateFreezeAtDef(Cond, ExitBlock->getParent(), Cond->getName() + ".fr");
 
   // Okay, now we have a position to branch from and a position to branch to,
   // insert the new conditional branch.
@@ -1149,7 +1149,7 @@ void LoopUnswitch::UnswitchNontrivialCondition(Value *LIC, Constant *Val,
 
   // Freeze
   IRBuilder<> Builder(loopPreheader);
-  Builder.CreateFreezeAtDef(LIC, loopPreheader->getParent(), LIC->getName() + ".fr");
+  LIC = Builder.CreateFreezeAtDef(LIC, loopPreheader->getParent(), LIC->getName() + ".fr");
   
   EmitPreheaderBranchOnCondition(LIC, Val, NewBlocks[0], LoopBlocks[0], OldBR,
                                  TI);

--- a/test/Transforms/InstCombine/select.ll
+++ b/test/Transforms/InstCombine/select.ll
@@ -1624,7 +1624,6 @@ define i32 @test_max_of_min(i32 %a) {
   ret i32 %s1
 }
 
-
 define i32 @PR23757(i32 %x) {
 ; CHECK-LABEL: @PR23757
 ; CHECK:      %[[cmp:.*]] = icmp eq i32 %x, 2147483647
@@ -1653,4 +1652,58 @@ define i32 @PR27137(i32 %a) {
   %c1 = icmp sgt i32 %s0, -1
   %s1 = select i1 %c1, i32 %s0, i32 -1
   ret i32 %s1
+}
+
+define i32 @test_foldselectopop_freeze(i32 %x, i32 %x2, i32 %x3, i1 %condorg, i1 %condorg2) {
+; CHECK-LABEL: @test_foldselectopop_freeze(
+; CHECK: %cond.fr = freeze i1 %cond
+; CHECK-NEXT: %tt = zext i1 %cond.fr to i32
+; CHECK-NEXT: %z.v = select i1 %cond.fr, i32 %x2, i32 %x3
+  %cond = or i1 %condorg, %condorg2
+  %tt = zext i1 %cond to i32
+  %y1 = udiv i32 %x, %x2
+  %y2 = udiv i32 %x, %x3
+  %z = select i1 %cond, i32 %y1, i32 %y2
+  %ttt = add i32 %tt, %z
+  ret i32 %ttt
+}
+
+@t1 = external global i32, align 4
+
+define i32 @test_foldselectopop_freeze2(i32 %x, i32 %x2, i32 %x3) {
+; CHECK-LABEL: @test_foldselectopop_freeze2(
+; CHECK: %.fr = freeze i1 icmp eq (i32 ptrtoint (i32* @t1 to i32), i32 305419896)
+; CHECK-NEXT: %z.v = select i1 %.fr, i32 %x2, i32 %x3
+; CHECK-NEXT: %z = udiv i32 %x, %z.v
+; CHECK-NEXT: %ttt = add i32 %z, zext (i1 icmp eq (i32 ptrtoint (i32* @t1 to i32), i32 305419896) to i32)
+  %y1 = udiv i32 %x, %x2
+  %y2 = udiv i32 %x, %x3
+  %z = select i1 icmp eq (i32 ptrtoint (i32* @t1 to i32), i32 305419896), i32 %y1, i32 %y2
+  %tt = zext i1 icmp eq (i32 ptrtoint (i32* @t1 to i32), i32 305419896) to i32
+  %ttt = add i32 %tt, %z
+  ret i32 %ttt
+}
+
+define i32 @test_foldselectopop_freeze3(i32 %x, i32 %x2, i32 %x3, i1 %cond) {
+; CHECK-LABEL: @test_foldselectopop_freeze3(
+; CHECK: %cond.fr = freeze i1 %cond
+; CHECK-NEXT: %z.v = select i1 %cond.fr, i32 %x2, i32 %x3
+; CHECK-NEXT: %z = udiv i32 %x, %z.v
+; CHECK-NEXT: %tt = zext i1 %cond.fr to i32
+  %y1 = udiv i32 %x, %x2
+  %y2 = udiv i32 %x, %x3
+  %z = select i1 %cond, i32 %y1, i32 %y2
+  %tt = zext i1 %cond to i32
+  %ttt = add i32 %tt, %z
+  ret i32 %ttt
+}
+
+define i32 @test_foldselectopop_freeze4(i32 %x, i32 %x2, i32 %x3, i1 %cond) {
+; CHECK-LABEL: @test_foldselectopop_freeze4(
+; CHECK: %z.v = select i1 %cond, i32 %x2, i32 %x3
+; CHECK-NEXT: %z = add i32 %z.v, %x
+  %y1 = add i32 %x, %x2
+  %y2 = add i32 %x, %x3
+  %z = select i1 %cond, i32 %y1, i32 %y2
+  ret i32 %z
 }

--- a/test/Transforms/LoopUnswitch/2011-11-18-SimpleSwitch.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-SimpleSwitch.ll
@@ -5,7 +5,8 @@
 ; STATS: 1 loop-simplify - Number of pre-header or exit blocks inserted
 ; STATS: 2 loop-unswitch - Number of switches unswitched
 
-; CHECK:      %1 = icmp eq i32 %c, 1
+; CHECK:      %c.fr = freeze i32 %c
+; CHECK-NEXT: %1 = icmp eq i32 %c.fr, 1
 ; CHECK-NEXT: br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -24,7 +25,7 @@
 ; CHECK-NEXT:   br label %loop_begin.backedge.us
 
 ; CHECK:      .split:                                           ; preds = %..split_crit_edge
-; CHECK-NEXT:   %2 = icmp eq i32 %c, 2
+; CHECK-NEXT:   %2 = icmp eq i32 %c.fr, 2
 ; CHECK-NEXT:   br i1 %2, label %.split.split.us, label %.split..split.split_crit_edge
 
 ; CHECK:      .split..split.split_crit_edge:                    ; preds = %.split
@@ -49,7 +50,7 @@
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split.split
 ; CHECK-NEXT:   %var_val = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c, label %default.us-lcssa.us-lcssa [
+; CHECK-NEXT:   switch i32 %c.fr, label %default.us-lcssa.us-lcssa [
 ; CHECK-NEXT:     i32 1, label %inc
 ; CHECK-NEXT:     i32 2, label %dec
 ; CHECK-NEXT:   ]

--- a/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches-Threshold.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches-Threshold.ll
@@ -7,7 +7,8 @@
 
 ; ModuleID = '../llvm/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll'
 
-; CHECK:        %1 = icmp eq i32 %c, 1
+; CHECK:        %c.fr = freeze i32 %c
+; CHECK:        %1 = icmp eq i32 %c.fr, 1
 ; CHECK-NEXT:   br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -33,7 +34,7 @@
 ; CHECK-NEXT:   br label %loop_begin
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split
-; CHECK:        switch i32 %c, label %second_switch [
+; CHECK:        switch i32 %c.fr, label %second_switch [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge
 ; CHECK-NEXT:   ]
 

--- a/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll
@@ -5,14 +5,16 @@
 ; STATS: 1 loop-simplify - Number of pre-header or exit blocks inserted
 ; STATS: 3 loop-unswitch - Number of switches unswitched
 
-; CHECK:        %1 = icmp eq i32 %c, 1
+; CHECK:        %c.fr = freeze i32 %c
+; CHECK:        %d.fr = freeze i32 %d
+; CHECK-NEXT:   %1 = icmp eq i32 %c.fr, 1
 ; CHECK-NEXT:   br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
 ; CHECK-NEXT:   br label %.split
 
 ; CHECK:      .split.us:                                        ; preds = %0
-; CHECK-NEXT:   %2 = icmp eq i32 %d, 1
+; CHECK-NEXT:   %2 = icmp eq i32 %d.fr, 1
 ; CHECK-NEXT:   br i1 %2, label %.split.us.split.us, label %.split.us..split.us.split_crit_edge
 
 ; CHECK:      .split.us..split.us.split_crit_edge:              ; preds = %.split.us
@@ -43,7 +45,7 @@
 ; CHECK-NEXT:     i32 1, label %inc.us
 
 ; CHECK:      second_switch.us:                                 ; preds = %loop_begin.us
-; CHECK-NEXT:   switch i32 %d, label %default.us [
+; CHECK-NEXT:   switch i32 %d.fr, label %default.us [
 ; CHECK-NEXT:     i32 1, label %second_switch.us.inc.us_crit_edge
 ; CHECK-NEXT:   ]
 
@@ -55,7 +57,7 @@
 ; CHECK-NEXT:   br label %loop_begin.backedge.us
 
 ; CHECK:      .split:                                           ; preds = %..split_crit_edge
-; CHECK-NEXT:   %3 = icmp eq i32 %d, 1
+; CHECK-NEXT:   %3 = icmp eq i32 %d.fr, 1
 ; CHECK-NEXT:   br i1 %3, label %.split.split.us, label %.split..split.split_crit_edge
 
 ; CHECK:      .split..split.split_crit_edge:                    ; preds = %.split
@@ -66,7 +68,7 @@
 
 ; CHECK:      loop_begin.us1:                                   ; preds = %loop_begin.backedge.us6, %.split.split.us
 ; CHECK-NEXT:   %var_val.us2 = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c, label %second_switch.us3 [
+; CHECK-NEXT:   switch i32 %c.fr, label %second_switch.us3 [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge.us
 ; CHECK-NEXT:   ]
 
@@ -87,7 +89,7 @@
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split.split
 ; CHECK-NEXT:   %var_val = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c, label %second_switch [
+; CHECK-NEXT:   switch i32 %c.fr, label %second_switch [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge
 ; CHECK-NEXT:   ]
 
@@ -95,7 +97,7 @@
 ; CHECK-NEXT:   br i1 true, label %us-unreachable.us-lcssa, label %inc
 
 ; CHECK:      second_switch:                                    ; preds = %loop_begin
-; CHECK-NEXT:   switch i32 %d, label %default [
+; CHECK-NEXT:   switch i32 %d.fr, label %default [
 ; CHECK-NEXT:     i32 1, label %second_switch.inc_crit_edge
 ; CHECK-NEXT:   ]
 

--- a/test/Transforms/LoopUnswitch/2015-06-17-Metadata.ll
+++ b/test/Transforms/LoopUnswitch/2015-06-17-Metadata.ll
@@ -16,7 +16,8 @@ for.body:                                         ; preds = %for.inc, %for.body.
   %cmp1 = icmp eq i32 %a, 12345
   br i1 %cmp1, label %if.then, label %if.else, !prof !0
 ; CHECK: %cmp1 = icmp eq i32 %a, 12345
-; CHECK-NEXT: br i1 %cmp1, label %for.body.us, label %for.body, !prof !0
+; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
+; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.us, label %for.body, !prof !0
 if.then:                                          ; preds = %for.body
 ; CHECK: for.body.us:
 ; CHECK: add nsw i32 %{{.*}}, 123
@@ -53,7 +54,8 @@ entry:
   br label %for.body
 ;CHECK: entry:
 ;CHECK-NEXT: %cmp1 = icmp eq i32 1, 2
-;CHECK-NEXT: br i1 %cmp1, label %for.body, label %for.cond.cleanup.split, !prof !1
+;CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
+;CHECK-NEXT: br i1 %cmp1.fr, label %for.body, label %for.cond.cleanup.split, !prof !1
 ;CHECK: for.body:
 for.body:                                         ; preds = %for.inc, %entry
   %inc.i = phi i32 [ 0, %entry ], [ %inc, %if.then ]

--- a/test/Transforms/LoopUnswitch/copy-metadata.ll
+++ b/test/Transforms/LoopUnswitch/copy-metadata.ll
@@ -3,7 +3,8 @@
 ; This test checks if unswitched condition preserve make.implicit metadata.
 
 define i32 @test(i1 %cond) {
-; CHECK: br i1 %cond, label %..split_crit_edge, label %.loop_exit.split_crit_edge, !make.implicit !0
+; CHECK: %cond.fr = freeze i1 %cond
+; CHECK-NEXT: br i1 %cond.fr, label %..split_crit_edge, label %.loop_exit.split_crit_edge, !make.implicit !0
   br label %loop_begin
 
 loop_begin:

--- a/test/Transforms/LoopUnswitch/infinite-loop.ll
+++ b/test/Transforms/LoopUnswitch/infinite-loop.ll
@@ -13,10 +13,12 @@
 
 ; CHECK-LABEL: @func_16(
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: br i1 %a, label %entry.split, label %abort0.split
+; CHECK-NEXT: %b.fr = freeze i1 %b
+; CHECK-NEXT: %a.fr = freeze i1 %a
+; CHECK-NEXT: br i1 %a.fr, label %entry.split, label %abort0.split
 
 ; CHECK: entry.split:
-; CHECK-NEXT: br i1 %b, label %for.body, label %abort1.split
+; CHECK-NEXT: br i1 %b.fr, label %for.body, label %abort1.split
 
 ; CHECK: for.body:
 ; CHECK-NEXT: br label %for.body

--- a/test/Transforms/LoopUnswitch/msan.ll
+++ b/test/Transforms/LoopUnswitch/msan.ll
@@ -122,7 +122,8 @@ define void @must_execute(i1 zeroext %x, i32 %p, i32 %q) sanitize_memory {
 entry:
 ; CHECK:       %[[Y:.*]] = load i64, i64* @y, align 8
 ; CHECK-NEXT:  %[[YB:.*]] = icmp eq i64 %[[Y]], 0
-; CHECK-NEXT:  br i1 %[[YB]],
+; CHECK-NEXT:  %[[YBF:.*]] = freeze i1 %[[YB]]
+; CHECK-NEXT:  br i1 %[[YBF]],
 
   %x2 = alloca i8, align 1
   %frombool1 = zext i1 %x to i8

--- a/test/Transforms/LoopUnswitch/trivial-unswitch.ll
+++ b/test/Transforms/LoopUnswitch/trivial-unswitch.ll
@@ -4,14 +4,15 @@
 ; LoopUnswitch pass should be able to unswitch the second one 
 ; after unswitching the first one.
 
-
-; CHECK:  br i1 %cond1, label %..split_crit_edge, label %.loop_exit.split_crit_edge
+; CHECK:  %cond2.fr = freeze i1 %cond2
+; CHECK:  %cond1.fr = freeze i1 %cond1
+; CHECK:  br i1 %cond1.fr, label %..split_crit_edge, label %.loop_exit.split_crit_edge
 
 ; CHECK:  ..split_crit_edge:                                ; preds = %0
 ; CHECK:    br label %.split
 
 ; CHECK:  .split:                                           ; preds = %..split_crit_edge
-; CHECK:    br i1 %cond2, label %.split..split.split_crit_edge, label %.split.loop_exit.split1_crit_edge
+; CHECK:    br i1 %cond2.fr, label %.split..split.split_crit_edge, label %.split.loop_exit.split1_crit_edge
 
 ; CHECK:  .split..split.split_crit_edge:                    ; preds = %.split
 ; CHECK:    br label %.split.split


### PR DESCRIPTION
### Summary
1. I modified `IRBuilder::CreateFreezeAtDef` (https://github.com/snu-sf/llvm-freeze/pull/22) to deny receiving a constant value. `IRBuilder::CreateFreezeAtDef` replaces all uses of a value, but uses of a constant can be other constants, and it makes assertion failure `"Cannot make Constant refer to non-constant!"`.
   For example, 

```
  %div = sdiv i32 %a, %b
  %div1 = sdiv i32 %a, %c
  %cond3.v = select i1 icmp eq (i32 ptrtoint (i32* @t to i32), i32 305419896), i32 %div, i32 %div1
  %cond3 = add i32 %cond3.v, zext (i1 icmp eq (i32 ptrtoint (i32* @t to i32), i32 305419896) to i32)
```

https://github.com/snu-sf/llvm-freeze/pull/22 tries to freeze the condition value of `%cond3.v` and replace all uses of it. One of uses of the condition is `zext (i1 icmp eq (i32 ptrtoint (i32* @t to i32), i32 305419896) to i32)`, but replacing it will make `zext` not constant. This PR prevents such replacements.
1. Loop-unswitch code in https://github.com/snu-sf/llvm-freeze/pull/22 used unfreezed condition value when unswitching branches. Previous loop-unswitch code(https://github.com/snu-sf/llvm-freeze/commit/9b103f3343e7c655f8fa8f3b94bb937966fd649a) correctly unswitched freezed condition value. I fixed the code in this PR.
2. I fixed llvm test cases which failed to pass `make check-llvm`. Now they pass `make check-llvm`. To prevent unexpected bug, I'll run `make check-llvm` before making PRs.
