### PR TITLE
Let loopunswitch/instcombine correctly deal with condition value from InvokeInst

### DIFF
--- a/include/llvm/IR/PatternMatch.h
+++ b/include/llvm/IR/PatternMatch.h
@@ -901,6 +901,25 @@ template <typename LHS> inline fneg_match<LHS> m_FNeg(const LHS &L) {
   return L;
 }
 
+template <typename Op_t> struct FreezeClass_match {
+  Op_t Op;
+
+  FreezeClass_match(const Op_t &OpMatch) : Op(OpMatch) {}
+
+  template <typename OpTy> bool match(OpTy *V) {
+    if (auto *O = dyn_cast<Operator>(V))
+      return O->getOpcode() == Instruction::Freeze && Op.match(O->getOperand(0));
+    return false;
+  }
+};
+
+/// \brief Matches Freeze.
+template <typename OpTy>
+inline FreezeClass_match<OpTy> m_Freeze(const OpTy &Op) {
+  return FreezeClass_match<OpTy>(Op);
+}
+
+
 //===----------------------------------------------------------------------===//
 // Matchers for control flow.
 //

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -211,7 +211,8 @@ Instruction *InstCombiner::FoldSelectOpOp(SelectInst &SI, Instruction *TI,
   case Instruction::URem:
   case Instruction::SDiv:
   case Instruction::SRem:
-    if (!isa<Constant>(SI.getCondition()))
+    if (!isa<Constant>(SI.getCondition()) && 
+        !isa<TerminatorInst>(SI.getCondition()))
       // Create Freeze at the definition of condition value, and
       // replace all uses of SI.getCondition() with the new freeze instruction.
       Cond = Builder->CreateFreezeAtDef(Cond,


### PR DESCRIPTION
Previously after freeze insertion we replaced all uses of the value with a new freezed value.
However it becomes tricky to determine where to put the freeze instruction when the value is from InvokeInst. (InvokeInst is a terminator instruction)
Being conservative, I modified the previous loop-unswitch / instcombine optimizations so they just insert `%cond.fr = freeze (%cond)` where they need, and don't replace all uses of `%cond`.

I tested with following examples -  
LoopUnswitch : 
https://github.com/aqjune/freezescript/blob/master/unittest/loopunswitch/run-invoke.ll
After freeze insertion : 
https://github.com/aqjune/freezescript/blob/master/unittest/loopunswitch/run-invoke.build.ll.answer

select (x / y, x / z) -> x / (select y, z) optimization : 
https://github.com/aqjune/freezescript/blob/master/unittest/select/select-invoke.ll
After freeze insertion : 
https://github.com/aqjune/freezescript/blob/master/unittest/select/select-invoke.build.ll.answer

This modification must be merged into codegen/codegen-freezecopy/gvnload branches as well.
