### PR TITLE
Let CodeGenPrepare move freeze for efficient X86 assembly generation

### DIFF
--- a/include/llvm/IR/PatternMatch.h
+++ b/include/llvm/IR/PatternMatch.h
@@ -901,6 +901,25 @@ template <typename LHS> inline fneg_match<LHS> m_FNeg(const LHS &L) {
   return L;
 }
 
+template <typename Op_t> struct FreezeClass_match {
+  Op_t Op;
+
+  FreezeClass_match(const Op_t &OpMatch) : Op(OpMatch) {}
+
+  template <typename OpTy> bool match(OpTy *V) {
+    if (auto *O = dyn_cast<Operator>(V))
+      return O->getOpcode() == Instruction::Freeze && Op.match(O->getOperand(0));
+    return false;
+  }
+};
+
+/// \brief Matches Freeze.
+template <typename OpTy>
+inline FreezeClass_match<OpTy> m_Freeze(const OpTy &Op) {
+  return FreezeClass_match<OpTy>(Op);
+}
+
+
 //===----------------------------------------------------------------------===//
 // Matchers for control flow.
 //

--- a/lib/CodeGen/CodeGenPrepare.cpp
+++ b/lib/CodeGen/CodeGenPrepare.cpp
@@ -767,9 +767,6 @@ static bool SinkCast(CastInst *CI) {
     // If the block selected to receive the cast is an EH pad that does not
     // allow non-PHI instructions before the terminator, we can't sink the
     // cast.
-    if (UserBB->getTerminator() == nullptr) {
-      outs() << "???? : \n" << *UserBB << "\n";
-    }
     if (UserBB->getTerminator()->isEHPad())
       continue;
 

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -211,7 +211,8 @@ Instruction *InstCombiner::FoldSelectOpOp(SelectInst &SI, Instruction *TI,
   case Instruction::URem:
   case Instruction::SDiv:
   case Instruction::SRem:
-    if (!isa<Constant>(SI.getCondition()))
+    if (!isa<Constant>(SI.getCondition()) && 
+        !isa<TerminatorInst>(SI.getCondition()))
       // Create Freeze at the definition of condition value, and
       // replace all uses of SI.getCondition() with the new freeze instruction.
       Cond = Builder->CreateFreezeAtDef(Cond,


### PR DESCRIPTION
#### Motivation

(I excerpted from email to Nuno)
`SelectionDAGBuilder::FindMergedConditions` function in SelectionDAGBuilder.cpp tries to split br (a && b) into two branches `br a ; br b` if branch operation is not expensive. (This optimization occurs while SelectionDAGBuilder::visitBr is translating IR to SelectionDAG)

The problem is that `SelectionDAGBuilder::FindMergedConditions` requires all relevant instructions to be in a same basic block. For example, `SelectionDAGBuilder::FindMergedConditions` can't optimize

```
A:
%a = icmp eq i32 %x, %y
br label %B
B:
%b = icmp eq i32 %z, %w
%c = and i1 %a, %b
br i1 %c, label %P, label %Q
```

because %a is not in block B.

For such case, prior to building SelectionDAG, CodeGenPrepare tries to sink such instructions. (ex. SinkCmpExpression() in CodeGenPrepare.cpp) It sinks `%a = icmp eq i32 %x, %y` from block A to B, so `SelectionDAGBuilder::FindMergedConditions` can work.
However, if %a is freezed like this : 

```
A:
%a = icmp eq i32 %x, %y
%a.fr = freeze i1 %a
br label %B
B:
%b = icmp eq i32 %z, %w
%c = and i1 %a.fr, %b
br i1 %c, label %P, label %Q
```

We can't sink %a and %a.fr into %B if %B can be executed multiple times (e.g. %B is in a loop)
This problem was the reason of performance degeneration of Shootout-C++/moments
 benchmark in LNT. It showed ~37% slowdown.

In order to resolve this case, one solution was suggested by Nuno : to convert `freeze(icmp op %x, const) => icmp op (freeze %x), const)`, so allow CodeGenPrepare to sink the `icmp` operation. I implemented CodeGenPrepare::optimizeFreezeInst which does the work.
#### Tests

I ran SPEC2006 `runspec` with `-validate` option for 19 C/C++ benchmarks, and checked they worked correctly.
I tested with : 
https://github.com/aqjune/freezescript/blob/master/unittest/x86jmp/x86branch-freeze2.ll
