### PR TITLE
Modify ScalarEvolution so it looks through freezed icmp in ScalarEvolution::isLoopEntryGuardedByCond

### DIFF
--- a/include/llvm/IR/PatternMatch.h
+++ b/include/llvm/IR/PatternMatch.h
@@ -901,6 +901,25 @@ template <typename LHS> inline fneg_match<LHS> m_FNeg(const LHS &L) {
   return L;
 }
 
+template <typename Op_t> struct FreezeClass_match {
+  Op_t Op;
+
+  FreezeClass_match(const Op_t &OpMatch) : Op(OpMatch) {}
+
+  template <typename OpTy> bool match(OpTy *V) {
+    if (auto *O = dyn_cast<Operator>(V))
+      return O->getOpcode() == Instruction::Freeze && Op.match(O->getOperand(0));
+    return false;
+  }
+};
+
+/// \brief Matches Freeze.
+template <typename OpTy>
+inline FreezeClass_match<OpTy> m_Freeze(const OpTy &Op) {
+  return FreezeClass_match<OpTy>(Op);
+}
+
+
 //===----------------------------------------------------------------------===//
 // Matchers for control flow.
 //

--- a/lib/Analysis/ScalarEvolution.cpp
+++ b/lib/Analysis/ScalarEvolution.cpp
@@ -7994,8 +7994,12 @@ ScalarEvolution::isLoopEntryGuardedByCond(const Loop *L,
         LoopEntryPredicate->isUnconditional())
       continue;
 
+    Value *Cond = LoopEntryPredicate->getCondition();
+    if (FreezeInst *FI = dyn_cast<FreezeInst>(Cond))
+      Cond = FI->getOperand(0);
+
     if (isImpliedCond(Pred, LHS, RHS,
-                      LoopEntryPredicate->getCondition(),
+                      Cond,
                       LoopEntryPredicate->getSuccessor(0) != Pair.second))
       return true;
   }

--- a/lib/CodeGen/CodeGenPrepare.cpp
+++ b/lib/CodeGen/CodeGenPrepare.cpp
@@ -767,9 +767,6 @@ static bool SinkCast(CastInst *CI) {
     // If the block selected to receive the cast is an EH pad that does not
     // allow non-PHI instructions before the terminator, we can't sink the
     // cast.
-    if (UserBB->getTerminator() == nullptr) {
-      outs() << "???? : \n" << *UserBB << "\n";
-    }
     if (UserBB->getTerminator()->isEHPad())
       continue;
 

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -211,7 +211,8 @@ Instruction *InstCombiner::FoldSelectOpOp(SelectInst &SI, Instruction *TI,
   case Instruction::URem:
   case Instruction::SDiv:
   case Instruction::SRem:
-    if (!isa<Constant>(SI.getCondition()))
+    if (!isa<Constant>(SI.getCondition()) && 
+        !isa<TerminatorInst>(SI.getCondition()))
       // Create Freeze at the definition of condition value, and
       // replace all uses of SI.getCondition() with the new freeze instruction.
       Cond = Builder->CreateFreezeAtDef(Cond,


### PR DESCRIPTION
This PR is related to the performance regression in LNT Polybench 'cholesky' test case.

By this patch, now backedge taken count analysis result is same regardless of the existence of freeze, like the case below

```
if (freeze(n > 0)) { // ScalarEvolution::isLoopEntryGuardedByCond now goes through freeze
  for(int i = 0; i < n; i++){
    ...
  }
}
```

For more detail, see https://github.com/aqjune/freezescript/tree/master/test/loopunroll .

(This PR should be merged after https://github.com/snu-sf/llvm-freeze/pull/31)
