### PR TITLE
Update loopunswitch so it does not freeze unnecessarily

### DIFF
--- a/include/llvm/Analysis/InstructionSimplify.h
+++ b/include/llvm/Analysis/InstructionSimplify.h
@@ -323,6 +323,14 @@ namespace llvm {
                       AssumptionCache *AC = nullptr,
                       const Instruction *CxtI = nullptr);
 
+  /// SimplifyFreezeInst - Given operands for a Freeze, see if we can
+  /// fold the result.  If not, this returns null.
+  Value *SimplifyFreezeInst(Value *Op, const DataLayout &DL,
+                         const TargetLibraryInfo *TLI = nullptr,
+                         const DominatorTree *DT = nullptr,
+                         AssumptionCache *AC = nullptr,
+                         const Instruction *CxtI = nullptr);
+
   /// SimplifyInstruction - See if we can compute a simplified version of this
   /// instruction.  If not, this returns null.
   Value *SimplifyInstruction(Instruction *I, const DataLayout &DL,

--- a/include/llvm/IR/LegacyPassManager.h
+++ b/include/llvm/IR/LegacyPassManager.h
@@ -18,6 +18,7 @@
 #define LLVM_IR_LEGACYPASSMANAGER_H
 
 #include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/CBindingWrapping.h"
 
 namespace llvm {
@@ -26,6 +27,9 @@ class Pass;
 class Module;
 
 namespace legacy {
+
+extern std::string ModuleDumpOutFileName;
+extern raw_ostream *ModuleDumpOutStream;
 
 class PassManagerImpl;
 class FunctionPassManagerImpl;

--- a/include/llvm/IR/PatternMatch.h
+++ b/include/llvm/IR/PatternMatch.h
@@ -901,6 +901,25 @@ template <typename LHS> inline fneg_match<LHS> m_FNeg(const LHS &L) {
   return L;
 }
 
+template <typename Op_t> struct FreezeClass_match {
+  Op_t Op;
+
+  FreezeClass_match(const Op_t &OpMatch) : Op(OpMatch) {}
+
+  template <typename OpTy> bool match(OpTy *V) {
+    if (auto *O = dyn_cast<Operator>(V))
+      return O->getOpcode() == Instruction::Freeze && Op.match(O->getOperand(0));
+    return false;
+  }
+};
+
+/// \brief Matches Freeze.
+template <typename OpTy>
+inline FreezeClass_match<OpTy> m_Freeze(const OpTy &Op) {
+  return FreezeClass_match<OpTy>(Op);
+}
+
+
 //===----------------------------------------------------------------------===//
 // Matchers for control flow.
 //

--- a/lib/Analysis/CallGraphSCCPass.cpp
+++ b/lib/Analysis/CallGraphSCCPass.cpp
@@ -24,6 +24,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManagers.h"
 #include "llvm/IR/OptBisect.h"
+#include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Timer.h"
@@ -629,7 +630,8 @@ char PrintCallGraphPass::ID = 0;
 
 Pass *CallGraphSCCPass::createPrinterPass(raw_ostream &O,
                                           const std::string &Banner) const {
-  return new PrintCallGraphPass(Banner, O);
+  return createPrintModulePass(O, Banner); 
+  //return new PrintCallGraphPass(Banner, O);
 }
 
 bool CallGraphSCCPass::skipSCC(CallGraphSCC &SCC) const {

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -4052,6 +4052,23 @@ Value *llvm::SimplifyCall(Value *V, ArrayRef<Value *> Args,
                         Query(DL, TLI, DT, AC, CxtI), RecursionLimit);
 }
 
+/// Given operands for a Freeze, see if we can fold the result.
+static Value *SimplifyFreezeInst(Value *Op0) {
+  // Currently we don't have constantexpr freeze, so just check
+  // whether it is a ConstantInt.
+  if (isa<ConstantInt>(Op0))
+    return Op0;
+  return nullptr;
+}
+
+Value *llvm::SimplifyFreezeInst(Value *Op0,
+                              const DataLayout &DL,
+                              const TargetLibraryInfo *TLI,
+                              const DominatorTree *DT, AssumptionCache *AC,
+                              const Instruction *CxtI) {
+  return ::SimplifyFreezeInst(Op0);
+}
+
 /// See if we can compute a simplified version of this instruction.
 /// If not, this returns null.
 Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
@@ -4194,6 +4211,10 @@ Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
   case Instruction::Trunc:
     Result =
         SimplifyTruncInst(I->getOperand(0), I->getType(), DL, TLI, DT, AC, I);
+    break;
+  case Instruction::Freeze:
+    Result = 
+        SimplifyFreezeInst(I->getOperand(0), DL, TLI, DT, AC, I);
     break;
   }
 

--- a/lib/Analysis/LoopPass.cpp
+++ b/lib/Analysis/LoopPass.cpp
@@ -31,26 +31,31 @@ namespace {
 /// PrintLoopPass - Print a Function corresponding to a Loop.
 ///
 class PrintLoopPassWrapper : public LoopPass {
-  PrintLoopPass P;
+  //PrintLoopPass P;
+  PrintModulePass P;
 
 public:
   static char ID;
   PrintLoopPassWrapper() : LoopPass(ID) {}
   PrintLoopPassWrapper(raw_ostream &OS, const std::string &Banner)
-      : LoopPass(ID), P(OS, Banner) {}
+      : LoopPass(ID), /*P(OS, Banner)*/P(OS, Banner, false) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();
   }
 
   bool runOnLoop(Loop *L, LPPassManager &) override {
-    auto BBI = find_if(L->blocks().begin(), L->blocks().end(),
+    ModuleAnalysisManager DummyMAM;
+    P.run(*(L->getHeader()->getParent()->getParent()), DummyMAM);  
+    /* 
+	auto BBI = find_if(L->blocks().begin(), L->blocks().end(),
                        [](BasicBlock *BB) { return BB; });
     if (BBI != L->blocks().end() &&
         isFunctionInPrintList((*BBI)->getParent()->getName())) {
       AnalysisManager<Loop> DummyLAM;
       P.run(*L, DummyLAM);
     }
+	*/
     return false;
   }
 };

--- a/lib/CodeGen/CodeGenPrepare.cpp
+++ b/lib/CodeGen/CodeGenPrepare.cpp
@@ -767,9 +767,6 @@ static bool SinkCast(CastInst *CI) {
     // If the block selected to receive the cast is an EH pad that does not
     // allow non-PHI instructions before the terminator, we can't sink the
     // cast.
-    if (UserBB->getTerminator() == nullptr) {
-      outs() << "???? : \n" << *UserBB << "\n";
-    }
     if (UserBB->getTerminator()->isEHPad())
       continue;
 

--- a/lib/IR/IRPrintingPasses.cpp
+++ b/lib/IR/IRPrintingPasses.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include <iostream>
 using namespace llvm;
 
 PrintModulePass::PrintModulePass() : OS(dbgs()) {}
@@ -73,18 +74,21 @@ public:
 };
 
 class PrintFunctionPassWrapper : public FunctionPass {
-  PrintFunctionPass P;
+  //PrintFunctionPass P;
+  PrintModulePass P;
 
 public:
   static char ID;
   PrintFunctionPassWrapper() : FunctionPass(ID) {}
   PrintFunctionPassWrapper(raw_ostream &OS, const std::string &Banner)
-      : FunctionPass(ID), P(OS, Banner) {}
+      : FunctionPass(ID), /*P(OS, Banner)*/P(OS, Banner, false) {}
 
   // This pass just prints a banner followed by the function as it's processed.
   bool runOnFunction(Function &F) override {
-    FunctionAnalysisManager DummyFAM;
-    P.run(F, DummyFAM);
+    //FunctionAnalysisManager DummyFAM;
+    ModuleAnalysisManager DummyMAM;
+	//P.run(F, DummyFAM);
+	P.run(*F.getParent(), DummyMAM);
     return false;
   }
 

--- a/lib/Transforms/InstCombine/InstCombineFreeze.cpp
+++ b/lib/Transforms/InstCombine/InstCombineFreeze.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "InstCombineInternal.h"
+#include "llvm/Analysis/InstructionSimplify.h"
 using namespace llvm;
 using namespace PatternMatch;
 
@@ -19,6 +20,10 @@ using namespace PatternMatch;
 
 Instruction *InstCombiner::visitFreeze(FreezeInst &FI) {
   Value *Op0 = FI.getOperand(0);
+
+  if (Value *V = SimplifyFreezeInst(Op0, DL, TLI, DT, AC))
+    return replaceInstUsesWith(FI, V);
+
   if (FreezeInst *Op0_FI = dyn_cast<FreezeInst>(Op0))
     return replaceInstUsesWith(FI, Op0_FI);
 

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -211,7 +211,8 @@ Instruction *InstCombiner::FoldSelectOpOp(SelectInst &SI, Instruction *TI,
   case Instruction::URem:
   case Instruction::SDiv:
   case Instruction::SRem:
-    if (!isa<Constant>(SI.getCondition()))
+    if (!isa<Constant>(SI.getCondition()) && 
+        !isa<TerminatorInst>(SI.getCondition()))
       // Create Freeze at the definition of condition value, and
       // replace all uses of SI.getCondition() with the new freeze instruction.
       Cond = Builder->CreateFreezeAtDef(Cond,

--- a/lib/Transforms/Scalar/LoopUnswitch.cpp
+++ b/lib/Transforms/Scalar/LoopUnswitch.cpp
@@ -37,6 +37,7 @@
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/BlockFrequencyInfoImpl.h"
 #include "llvm/Analysis/BlockFrequencyInfo.h"
@@ -239,11 +240,13 @@ namespace {
     bool TryTrivialLoopUnswitch(bool &Changed);
 
     bool UnswitchIfProfitable(Value *LoopCond, Constant *Val,
-                              TerminatorInst *TI = nullptr);
+                              TerminatorInst *TI = nullptr,
+                              bool NeedFreeze = true);
     void UnswitchTrivialCondition(Loop *L, Value *Cond, Constant *Val,
-                                  BasicBlock *ExitBlock, TerminatorInst *TI);
+                                  BasicBlock *ExitBlock, TerminatorInst *TI,
+                                  bool NeedFreeze);
     void UnswitchNontrivialCondition(Value *LIC, Constant *OnVal, Loop *L,
-                                     TerminatorInst *TI);
+                                     TerminatorInst *TI, bool NeedFreeze);
 
     void RewriteLoopBodyWithConditionConstant(Loop *L, Value *LIC,
                                               Constant *Val, bool isEqual);
@@ -566,7 +569,8 @@ bool LoopUnswitch::processCurrentLoop() {
     Value *LoopCond =
         FindLIVLoopCondition(Guard->getOperand(0), currentLoop, Changed);
     if (LoopCond &&
-        UnswitchIfProfitable(LoopCond, ConstantInt::getTrue(Context))) {
+        UnswitchIfProfitable(LoopCond, ConstantInt::getTrue(Context),
+                             nullptr, true)) {
       // NB! Unswitching (if successful) could have erased some of the
       // instructions in Guards leaving dangling pointers there.  This is fine
       // because we're returning now, and won't look at Guards again.
@@ -592,6 +596,56 @@ bool LoopUnswitch::processCurrentLoop() {
         !isGuaranteedToExecute(*TI, DT, currentLoop, &SafetyInfo))
       continue;
 
+    // Do we need to freeze condition of TI?
+    // Here we use simple heuristic : 
+    // If TI is in header, and all instructions
+    // between header beginning and TI are guaranteed to transfer execution
+    // to successor, then don't freeze.
+    bool NeedFreeze = true;
+    {
+      bool UnconditionallyGotoTI = true;
+      BasicBlock *BB = currentLoop->getHeader();
+      while (BB) {
+        TerminatorInst *BBTI = BB->getTerminator();
+        if (BBTI == TI)
+          // There's a unique path from header to TI
+          break;
+        else if (BBTI->getNumSuccessors() == 1)
+          BB = BBTI->getSuccessor(0);
+        else {
+          BB = nullptr;
+          UnconditionallyGotoTI = false;
+        }
+      }
+      if (UnconditionallyGotoTI) {
+        // Now we check whether all instructions from header to
+        // TI guarantees to transfer execution to successor.
+        NeedFreeze = false;
+        BB = currentLoop->getHeader();
+        while (BB) {
+          for(auto I = BB->begin(), E = BB->end(); I != E; ) {
+            Instruction *Inst = &(*I);
+            if (!isGuaranteedToTransferExecutionToSuccessor(Inst)) {
+              NeedFreeze = true;
+              break;
+            }
+            ++I;
+          }
+          if (NeedFreeze) break;
+
+          TerminatorInst *BBTI = BB->getTerminator();
+          if (BBTI == TI)
+            // There's a unique path from header to TI
+            break;
+          else {
+            assert ((BBTI->getNumSuccessors() == 1) &&
+                    "Should have no more than 1 successors");
+            BB = BBTI->getSuccessor(0);
+          }
+        }
+      }
+    }
+
     if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
       // If this isn't branching on an invariant condition, we can't unswitch
       // it.
@@ -600,8 +654,11 @@ bool LoopUnswitch::processCurrentLoop() {
         // unswitch on it if we desire.
         Value *LoopCond = FindLIVLoopCondition(BI->getCondition(),
                                                currentLoop, Changed);
+        // Determine whether to freeze condition variable or not.
+        // This branch (BI) must be guaranteed to execute, e.g. 
         if (LoopCond &&
-            UnswitchIfProfitable(LoopCond, ConstantInt::getTrue(Context), TI)) {
+            UnswitchIfProfitable(LoopCond, ConstantInt::getTrue(Context), TI,
+                                 NeedFreeze)) {
           ++NumBranches;
           return true;
         }
@@ -631,7 +688,7 @@ bool LoopUnswitch::processCurrentLoop() {
         if (!UnswitchVal)
           continue;
 
-        if (UnswitchIfProfitable(LoopCond, UnswitchVal)) {
+        if (UnswitchIfProfitable(LoopCond, UnswitchVal, nullptr, NeedFreeze)) {
           ++NumSwitches;
           return true;
         }
@@ -645,7 +702,8 @@ bool LoopUnswitch::processCurrentLoop() {
         Value *LoopCond = FindLIVLoopCondition(SI->getCondition(),
                                                currentLoop, Changed);
         if (LoopCond && UnswitchIfProfitable(LoopCond,
-                                             ConstantInt::getTrue(Context))) {
+                                             ConstantInt::getTrue(Context),
+                                             nullptr, true)) {
           ++NumSelects;
           return true;
         }
@@ -708,7 +766,8 @@ static BasicBlock *isTrivialLoopExitBlock(Loop *L, BasicBlock *BB) {
 /// simplify the loop.  If we decide that this is profitable,
 /// unswitch the loop, reprocess the pieces, then return true.
 bool LoopUnswitch::UnswitchIfProfitable(Value *LoopCond, Constant *Val,
-                                        TerminatorInst *TI) {
+                                        TerminatorInst *TI,
+                                        bool NeedFreeze) {
   // Check to see if it would be profitable to unswitch current loop.
   if (!BranchesInfo.CostAllowsUnswitching()) {
     DEBUG(dbgs() << "NOT unswitching loop %"
@@ -719,7 +778,7 @@ bool LoopUnswitch::UnswitchIfProfitable(Value *LoopCond, Constant *Val,
     return false;
   }
 
-  UnswitchNontrivialCondition(LoopCond, Val, currentLoop, TI);
+  UnswitchNontrivialCondition(LoopCond, Val, currentLoop, TI, NeedFreeze);
   return true;
 }
 
@@ -816,7 +875,8 @@ void LoopUnswitch::EmitPreheaderBranchOnCondition(Value *LIC, Constant *Val,
 /// outside of the loop and updating loop info.
 void LoopUnswitch::UnswitchTrivialCondition(Loop *L, Value *Cond, Constant *Val,
                                             BasicBlock *ExitBlock,
-                                            TerminatorInst *TI) {
+                                            TerminatorInst *TI,
+                                            bool NeedFreeze) {
   DEBUG(dbgs() << "loop-unswitch: Trivial-Unswitch loop %"
                << loopHeader->getName() << " [" << L->getBlocks().size()
                << " blocks] in Function "
@@ -840,15 +900,18 @@ void LoopUnswitch::UnswitchTrivialCondition(Loop *L, Value *Cond, Constant *Val,
   BasicBlock *NewExit = SplitBlock(ExitBlock, &ExitBlock->front(), DT, LI);
 
   // Freeze
-  IRBuilder<> Builder(ExitBlock);
-  if (isa<TerminatorInst>(Cond)) {
-    // Terminator with a return value.
-    // InvokeInst is the only case now (LLVM 3.9)
-    FreezeInst *FI = new FreezeInst(Cond, Cond->getName() + ".fr");
-    FI->insertBefore(loopPreheader->getTerminator());
-    Cond = FI;
-  } else {
-    Cond = Builder.CreateFreezeAtDef(Cond, ExitBlock->getParent(), Cond->getName() + ".fr");
+  if (NeedFreeze) {
+    IRBuilder<> Builder(NewPH);
+    if (isa<TerminatorInst>(Cond)) {
+      // Terminator with a return value.
+      // InvokeInst is the only case now (LLVM 3.9)
+      FreezeInst *FI = new FreezeInst(Cond, Cond->getName() + ".fr");
+      FI->insertBefore(loopPreheader->getTerminator());
+      Cond = FI;
+    } else {
+      Cond = Builder.CreateFreezeAtDef(Cond, ExitBlock->getParent(),
+                                       Cond->getName() + ".fr");
+    }
   }
 
   // Okay, now we have a position to branch from and a position to branch to,
@@ -895,6 +958,11 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
   // this scenario could be very common in practice.
   SmallSet<BasicBlock*, 8> Visited;
 
+  // If there exists an instruction I which is (1) between the beginning of
+  // the loop header and a branch to unswitch, and (1) not guaranteed to 
+  // transfer execution to successor, then we need to freeze the condition,
+  // because if condition is poison it may introduce br poison, which is UB.
+  bool NeedFreeze = false;
   while (true) {
     // If we exit loop or reach a previous visited block, then
     // we can not reach any trivial condition candidates (unfoldable
@@ -906,9 +974,15 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
     // Check if this loop will execute any side-effecting instructions (e.g.
     // stores, calls, volatile loads) in the part of the loop that the code
     // *would* execute. Check the header first.
-    for (Instruction &I : *CurrentBB)
+    for (Instruction &I : *CurrentBB) {
       if (I.mayHaveSideEffects())
         return false;
+      if (!NeedFreeze
+          && isGuaranteedToTransferExecutionToSuccessor(&I))
+        // There exists an instruction which can exit from the loop.
+        // Hoisting branch must not have poison as its condition.
+        NeedFreeze = true;
+    }
 
     // FIXME: add check for constant foldable switch instructions.
     if (BranchInst *BI = dyn_cast<BranchInst>(CurrentTerm)) {
@@ -965,7 +1039,7 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
       return false;   // Can't handle this.
 
     UnswitchTrivialCondition(currentLoop, LoopCond, CondVal, LoopExitBB,
-                             CurrentTerm);
+                             CurrentTerm, NeedFreeze);
     ++NumBranches;
     return true;
   } else if (SwitchInst *SI = dyn_cast<SwitchInst>(CurrentTerm)) {
@@ -1008,7 +1082,7 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
       return false;   // Can't handle this.
 
     UnswitchTrivialCondition(currentLoop, LoopCond, CondVal, LoopExitBB,
-                             nullptr);
+                             nullptr, NeedFreeze);
     ++NumSwitches;
     return true;
   }
@@ -1036,7 +1110,8 @@ void LoopUnswitch::SplitExitEdges(Loop *L,
 /// Split it into loop versions and test the condition outside of either loop.
 /// Return the loops created as Out1/Out2.
 void LoopUnswitch::UnswitchNontrivialCondition(Value *LIC, Constant *Val,
-                                               Loop *L, TerminatorInst *TI) {
+                                               Loop *L, TerminatorInst *TI,
+                                               bool NeedFreeze) {
   Function *F = loopHeader->getParent();
   DEBUG(dbgs() << "loop-unswitch: Unswitching loop %"
         << loopHeader->getName() << " [" << L->getBlocks().size()
@@ -1155,20 +1230,22 @@ void LoopUnswitch::UnswitchNontrivialCondition(Value *LIC, Constant *Val,
 
   // Emit the new branch that selects between the two versions of this loop.
 
-  // Freeze
-  IRBuilder<> Builder(loopPreheader);
-  if (isa<TerminatorInst>(LIC)) {
-    // Terminator with a return value.
-    // InvokeInst is the only case now (LLVM 3.9)
-    FreezeInst *FI = new FreezeInst(LIC, LIC->getName() + ".fr");
-    FI->insertBefore(OldBR);
-    LIC = FI;
-  } else {
-    // Put freeze at def of LIC, and replace all uses with new freeze
-    LIC = Builder.CreateFreezeAtDef(LIC, loopPreheader->getParent(),
-                                    LIC->getName() + ".fr");
+  if (NeedFreeze) {
+    // Freeze the condition
+    IRBuilder<> Builder(loopPreheader);
+    if (isa<TerminatorInst>(LIC)) {
+      // Terminator with a return value.
+      // InvokeInst is the only case now (LLVM 3.9)
+      FreezeInst *FI = new FreezeInst(LIC, LIC->getName() + ".fr");
+      FI->insertBefore(OldBR);
+      LIC = FI;
+    } else {
+      // Put freeze at def of LIC, and replace all uses with new freeze
+      LIC = Builder.CreateFreezeAtDef(LIC, loopPreheader->getParent(),
+                                      LIC->getName() + ".fr");
+    }
   }
-  
+
   EmitPreheaderBranchOnCondition(LIC, Val, NewBlocks[0], LoopBlocks[0], OldBR,
                                  TI);
   LPM->deleteSimpleAnalysisValue(OldBR, L);

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -427,6 +427,8 @@ int main(int argc, char **argv) {
     }
   }
 
+  llvm::legacy::ModuleDumpOutFileName = InputFilename + ".passdump"; 
+  
   Triple ModuleTriple(M->getTargetTriple());
   std::string CPUStr, FeaturesStr;
   TargetMachine *Machine = nullptr;


### PR DESCRIPTION
Don't freeze condition in loop unswitching if the unswitching branch is guaranteed to be reachable from a loop preheader. It must satisfy following two conditions : 
- The loop preheader unconditionally jumps to block A1, A1 unconditionally jumps to A2, ..., and An has the branch instruction (to unswitch).
- All instructions in the blocks (loop preheader, A1, A2, ....) must satisfy isGuaranteedToTransferExecutionToSuccessor.