### PR TITLE
[PATCH - iteration 2] Freeze branch condition in LU

### DIFF
--- a/include/llvm-c/Core.h
+++ b/include/llvm-c/Core.h
@@ -134,7 +134,10 @@ typedef enum {
   LLVMCatchRet       = 62,
   LLVMCatchPad       = 63,
   LLVMCleanupPad     = 64,
-  LLVMCatchSwitch    = 65
+  LLVMCatchSwitch    = 65,
+
+  /* Freeze operator */
+  LLVMFreeze         = 66
 } LLVMOpcode;
 
 typedef enum {
@@ -1237,7 +1240,8 @@ LLVMTypeRef LLVMX86MMXType(void);
           macro(ZExtInst)                   \
         macro(ExtractValueInst)             \
         macro(LoadInst)                     \
-        macro(VAArgInst)
+        macro(VAArgInst)                    \
+        macro(FreezeInst)
 
 /**
  * @defgroup LLVMCCoreValueGeneral General APIs
@@ -3019,6 +3023,8 @@ LLVMValueRef LLVMBuildExtractValue(LLVMBuilderRef, LLVMValueRef AggVal,
                                    unsigned Index, const char *Name);
 LLVMValueRef LLVMBuildInsertValue(LLVMBuilderRef, LLVMValueRef AggVal,
                                   LLVMValueRef EltVal, unsigned Index,
+                                  const char *Name);
+LLVMValueRef LLVMBuildFreeze(LLVMBuilderRef, LLVMValueRef Val,
                                   const char *Name);
 
 LLVMValueRef LLVMBuildIsNull(LLVMBuilderRef, LLVMValueRef Val,

--- a/include/llvm/Analysis/InstructionSimplify.h
+++ b/include/llvm/Analysis/InstructionSimplify.h
@@ -291,6 +291,14 @@ namespace llvm {
                       AssumptionCache *AC = nullptr,
                       const Instruction *CxtI = nullptr);
 
+  /// SimplifyFreezeInst - Given an operand for a Freeze, see if we can
+  /// fold the result.  If not, this returns null.
+  Value *SimplifyFreezeInst(Value *Op, const DataLayout &DL,
+                         const TargetLibraryInfo *TLI = nullptr,
+                         const DominatorTree *DT = nullptr,
+                         AssumptionCache *AC = nullptr,
+                         const Instruction *CxtI = nullptr);
+
   /// See if we can compute a simplified version of this instruction. If not,
   /// return null.
   Value *SimplifyInstruction(Instruction *I, const DataLayout &DL,

--- a/include/llvm/Analysis/ValueTracking.h
+++ b/include/llvm/Analysis/ValueTracking.h
@@ -402,6 +402,10 @@ template <typename T> class ArrayRef;
   /// the parent of I.
   bool isKnownNotFullPoison(const Instruction *PoisonI);
 
+  /// Return true if this function can prove that V is never undef value
+  /// or poison value.
+  bool isGuaranteedNotToBeUndefOrPoison(const Value *V);
+
   /// \brief Specific patterns of select instructions we can match.
   enum SelectPatternFlavor {
     SPF_UNKNOWN = 0,

--- a/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/include/llvm/Bitcode/LLVMBitCodes.h
@@ -462,6 +462,7 @@ enum FunctionCodes {
   // 53 is unused.
   // 54 is unused.
   FUNC_CODE_OPERAND_BUNDLE = 55, // OPERAND_BUNDLE: [tag#, value...]
+  FUNC_CODE_INST_FREEZE = 56,    // FREEZE: [opty, opval]
 };
 
 enum UseListCodes {

--- a/include/llvm/CodeGen/ISDOpcodes.h
+++ b/include/llvm/CodeGen/ISDOpcodes.h
@@ -177,6 +177,9 @@ namespace ISD {
     /// UNDEF - An undefined node.
     UNDEF,
 
+    // FREEZE - A freeze node
+    FREEZE,
+
     /// EXTRACT_ELEMENT - This is used to get the lower or upper (determined by
     /// a Constant, which is required to be operand #1) half of the integer or
     /// float value specified as operand #0.  This is only for use before

--- a/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/include/llvm/CodeGen/SelectionDAGISel.h
@@ -265,6 +265,8 @@ private:
   void Select_UNDEF(SDNode *N);
   void CannotYetSelect(SDNode *N);
 
+  void Select_FREEZE(SDNode *N);
+
 private:
   void DoInstructionSelection();
   SDNode *MorphNode(SDNode *Node, unsigned TargetOpc, SDVTList VTs,

--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -1690,6 +1690,10 @@ public:
     return Insert(LandingPadInst::Create(Ty, NumClauses), Name);
   }
 
+  Value *CreateFreeze(Value *V, const Twine &Name = "") {
+    return Insert(new FreezeInst(V), Name);
+  }
+
   //===--------------------------------------------------------------------===//
   // Utility creation methods
   //===--------------------------------------------------------------------===//
@@ -1704,6 +1708,37 @@ public:
   Value *CreateIsNotNull(Value *Arg, const Twine &Name = "") {
     return CreateICmpNE(Arg, Constant::getNullValue(Arg->getType()),
                         Name);
+  }
+
+  /// \brief Insert a freeze instruction at the definition of \p Arg and return 
+  /// the new value.
+  Value *CreateFreezeAtDef(Value *Arg, Function *F, const Twine &Name = "",
+                           bool replaceAllUses = true) {
+    FreezeInst *FI = nullptr;
+
+    if (Instruction *I = dyn_cast<Instruction>(Arg)) {
+      FI = new FreezeInst(I, Name);
+      BasicBlock *BB = I->getParent();
+
+      if (isa<PHINode>(I)) {
+        BB->getInstList().insert(BB->getFirstInsertionPt(), FI);
+      } else if (isa<InvokeInst>(I)) {
+        // invoke is a terminator, so we have to put freeze into
+        // the beginning of its branch.
+        assert (!isa<InvokeInst>(I) && "Cannot put Freeze at def of terminator.");
+      } else {
+        FI->insertAfter(I);
+      }
+    } else if (Argument *A = dyn_cast<Argument>(Arg)) {
+      BasicBlock &Entry = F->getEntryBlock();
+      FI = new FreezeInst(Arg, Name, &*Entry.getFirstInsertionPt());
+    }
+
+    if (replaceAllUses && FI) {
+      Arg->replaceAllUsesWith(FI);
+      FI->replaceUsesOfWith(FI, Arg);
+    }
+    return FI;
   }
 
   /// \brief Return the i64 difference between two pointer values, dividing out

--- a/include/llvm/IR/InstVisitor.h
+++ b/include/llvm/IR/InstVisitor.h
@@ -206,6 +206,7 @@ public:
   RetTy visitFuncletPadInst(FuncletPadInst &I) { DELEGATE(Instruction); }
   RetTy visitCleanupPadInst(CleanupPadInst &I) { DELEGATE(FuncletPadInst); }
   RetTy visitCatchPadInst(CatchPadInst &I)     { DELEGATE(FuncletPadInst); }
+  RetTy visitFreezeInst(FreezeInst &I)         { DELEGATE(Instruction); }
 
   // Handle the special instrinsic instruction classes.
   RetTy visitDbgDeclareInst(DbgDeclareInst &I)    { DELEGATE(DbgInfoIntrinsic);}

--- a/include/llvm/IR/Instruction.def
+++ b/include/llvm/IR/Instruction.def
@@ -194,7 +194,8 @@ HANDLE_OTHER_INST(61, ShuffleVector, ShuffleVectorInst)  // shuffle two vectors.
 HANDLE_OTHER_INST(62, ExtractValue, ExtractValueInst)// extract from aggregate
 HANDLE_OTHER_INST(63, InsertValue, InsertValueInst)  // insert into aggregate
 HANDLE_OTHER_INST(64, LandingPad, LandingPadInst)  // Landing pad instruction.
-  LAST_OTHER_INST(64)
+HANDLE_OTHER_INST(65, Freeze, FreezeInst) // Freeze instruction.
+  LAST_OTHER_INST(65)
 
 #undef  FIRST_TERM_INST
 #undef HANDLE_TERM_INST

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -5056,6 +5056,44 @@ public:
   }
 };
 
+//===----------------------------------------------------------------------===//
+//                              FreezeInst Class
+//===----------------------------------------------------------------------===//
+
+/// This class represents a freeze function that returns random concrete
+/// value if an operand is either a poison value or an undefine value
+class FreezeInst : public UnaryInstruction {
+protected:
+  // Note: Instruction needs to be a friend here to call cloneImpl.
+  friend class Instruction;
+
+  /// Clone an identical FreezeInst
+  FreezeInst *cloneImpl() const;
+
+public:
+  /// Constructor with insert-before-instruction semantics
+  FreezeInst(
+    Value *S,                           ///< The value to freeze
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+  );
+
+  /// Constructor with insert-at-end-of-block semantics
+  FreezeInst(
+    Value *S,                     ///< The value to freeze
+    const Twine &NameStr,         ///< A name for the new instruction
+    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+  );
+
+  // Methods for support type inquiry through isa, cast, and dyn_cast:
+  static inline bool classof(const Instruction *I) {
+    return I->getOpcode() == Freeze;
+  }
+  static inline bool classof(const Value *V) {
+    return isa<Instruction>(V) && classof(cast<Instruction>(V));
+  }
+};
+
 } // end namespace llvm
 
 #endif // LLVM_IR_INSTRUCTIONS_H

--- a/include/llvm/IR/PatternMatch.h
+++ b/include/llvm/IR/PatternMatch.h
@@ -913,6 +913,25 @@ template <typename LHS> inline fneg_match<LHS> m_FNeg(const LHS &L) {
   return L;
 }
 
+template <typename Op_t> struct FreezeClass_match {
+  Op_t Op;
+
+  FreezeClass_match(const Op_t &OpMatch) : Op(OpMatch) {}
+
+  template <typename OpTy> bool match(OpTy *V) {
+    if (auto *O = dyn_cast<Operator>(V))
+      return O->getOpcode() == Instruction::Freeze &&
+             Op.match(O->getOperand(0));
+    return false;
+  }
+};
+
+/// \brief Matches Freeze.
+template <typename OpTy>
+inline FreezeClass_match<OpTy> m_Freeze(const OpTy &Op) {
+  return FreezeClass_match<OpTy>(Op);
+}
+
 //===----------------------------------------------------------------------===//
 // Matchers for control flow.
 //

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -4393,6 +4393,23 @@ Value *llvm::SimplifyCall(Value *V, ArrayRef<Value *> Args,
                         Query(DL, TLI, DT, AC, CxtI), RecursionLimit);
 }
 
+/// Given operands for a Freeze, see if we can fold the result.
+static Value *SimplifyFreezeInst(Value *Op0) {
+  // Use a utility function defined in ValueTracking.
+  if (llvm::isGuaranteedNotToBeUndefOrPoison(Op0))
+    return Op0;
+  // We have room for improvement.
+  return nullptr;
+}
+
+Value *llvm::SimplifyFreezeInst(Value *Op0,
+                              const DataLayout &DL,
+                              const TargetLibraryInfo *TLI,
+                              const DominatorTree *DT, AssumptionCache *AC,
+                              const Instruction *CxtI) {
+  return ::SimplifyFreezeInst(Op0);
+}
+
 /// See if we can compute a simplified version of this instruction.
 /// If not, this returns null.
 Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
@@ -4532,6 +4549,9 @@ Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
                           TLI, DT, AC, I);
     break;
   }
+  case Instruction::Freeze:
+    Result = SimplifyFreezeInst(I->getOperand(0), DL, TLI, DT, AC, I);
+    break;
 #define HANDLE_CAST_INST(num, opc, clas) case Instruction::opc:
 #include "llvm/IR/Instruction.def"
 #undef HANDLE_CAST_INST

--- a/lib/Analysis/ValueTracking.cpp
+++ b/lib/Analysis/ValueTracking.cpp
@@ -3898,6 +3898,28 @@ bool llvm::isKnownNotFullPoison(const Instruction *PoisonI) {
   return false;
 }
 
+bool llvm::isGuaranteedNotToBeUndefOrPoison(const Value *V) {
+  if (const Instruction *I = dyn_cast<Instruction>(V)) {
+    // If the value is a freeze instruction, then it can never
+    // be undef or poison.
+    if (isa<FreezeInst>(I))
+      return true;
+    // Here we just stay conservative.
+    return false;
+  }
+
+  if (const Constant *C = dyn_cast<Constant>(V)) {
+    // If the value is a constant integer, then return true.
+    if (isa<ConstantInt>(C))
+      return true;
+    // Note that we have much room for improvement.
+    return false;
+  }
+
+  return false;
+}
+
+
 static bool isKnownNonNaN(const Value *V, FastMathFlags FMF) {
   if (FMF.noNaNs())
     return true;

--- a/lib/AsmParser/LLLexer.cpp
+++ b/lib/AsmParser/LLLexer.cpp
@@ -784,6 +784,8 @@ lltok::Kind LLLexer::LexIdentifier() {
   INSTKEYWORD(catchpad,     CatchPad);
   INSTKEYWORD(cleanuppad,   CleanupPad);
 
+  INSTKEYWORD(freeze,       Freeze);
+
 #undef INSTKEYWORD
 
 #define DWKEYWORD(TYPE, TOKEN)                                                 \

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -5103,6 +5103,7 @@ int LLParser::ParseInstruction(Instruction *&Inst, BasicBlock *BB,
   case lltok::kw_shufflevector:  return ParseShuffleVector(Inst, PFS);
   case lltok::kw_phi:            return ParsePHI(Inst, PFS);
   case lltok::kw_landingpad:     return ParseLandingPad(Inst, PFS);
+  case lltok::kw_freeze:         return ParseFreeze(Inst, PFS);
   // Call.
   case lltok::kw_call:     return ParseCall(Inst, PFS, CallInst::TCK_None);
   case lltok::kw_tail:     return ParseCall(Inst, PFS, CallInst::TCK_Tail);
@@ -5898,6 +5899,21 @@ bool LLParser::ParseLandingPad(Instruction *&Inst, PerFunctionState &PFS) {
   }
 
   Inst = LP.release();
+  return false;
+}
+
+/// ParseFreeze
+///   ::= 'freeze' Type Value
+bool LLParser::ParseFreeze(Instruction *&Inst, PerFunctionState &PFS) {
+  LocTy Loc;
+  Value *Op;
+  if (ParseTypeAndValue(Op, Loc, PFS))
+    return true;
+
+  if (!Op->getType()->isIntegerTy())
+    return Error(Loc,"cannot freeze non-integer type");
+
+  Inst = new FreezeInst(Op, "");
   return false;
 }
 

--- a/lib/AsmParser/LLParser.h
+++ b/lib/AsmParser/LLParser.h
@@ -498,6 +498,7 @@ namespace llvm {
     int ParseGetElementPtr(Instruction *&I, PerFunctionState &PFS);
     int ParseExtractValue(Instruction *&I, PerFunctionState &PFS);
     int ParseInsertValue(Instruction *&I, PerFunctionState &PFS);
+    bool ParseFreeze(Instruction *&I, PerFunctionState &PFS);
 
     // Use-list order directives.
     bool ParseUseListOrder(PerFunctionState *PFS = nullptr);

--- a/lib/AsmParser/LLToken.h
+++ b/lib/AsmParser/LLToken.h
@@ -325,6 +325,8 @@ enum Kind {
   kw_insertvalue,
   kw_blockaddress,
 
+  kw_freeze,
+
   // Metadata types.
   kw_distinct,
 

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4338,6 +4338,19 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       OperandBundles.emplace_back(BundleTags[Record[0]], std::move(Inputs));
       continue;
     }
+
+    case bitc::FUNC_CODE_INST_FREEZE: { // FREEZE: [opty,opval]
+      unsigned OpNum = 0;
+      Value *Op = nullptr;
+      if (getValueTypePair(Record, OpNum, NextValueNo, Op))
+        return error("Invalid record");
+      if (OpNum != Record.size())
+        return error("Invalid record");
+
+      I = new FreezeInst(Op, "");
+      InstructionList.push_back(I);
+      break;
+    }
     }
 
     // Add instruction to end of current BB.  If there is no current BB, reject

--- a/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -2814,6 +2814,10 @@ void ModuleBitcodeWriter::writeInstruction(const Instruction &I,
     pushValue(I.getOperand(0), InstID, Vals);                   // valist.
     Vals.push_back(VE.getTypeID(I.getType())); // restype.
     break;
+  case Instruction::Freeze:
+    Code = bitc::FUNC_CODE_INST_FREEZE;
+    pushValueAndType(I.getOperand(0), InstID, Vals);
+    break;
   }
 
   Stream.EmitRecord(Code, Vals, AbbrevToUse);

--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -154,6 +154,9 @@ void DAGTypeLegalizer::PromoteIntegerResult(SDNode *N, unsigned ResNo) {
   case ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS:
     Res = PromoteIntRes_AtomicCmpSwap(cast<AtomicSDNode>(N), ResNo);
     break;
+  case ISD::FREEZE:
+    Res = PromoteIntRes_FREEZE(N);
+    break;
   }
 
   // If the result is null then the sub-method took care of registering it.
@@ -301,6 +304,12 @@ SDValue DAGTypeLegalizer::PromoteIntRes_BITCAST(SDNode *N) {
 
   return DAG.getNode(ISD::ANY_EXTEND, dl, NOutVT,
                      CreateStackStoreLoad(InOp, OutVT));
+}
+
+SDValue DAGTypeLegalizer::PromoteIntRes_FREEZE(SDNode *N) {
+  SDValue V = GetPromotedInteger(N->getOperand(0));
+  return DAG.getNode(N->getOpcode(), SDLoc(N),
+                     V.getValueType(), V);
 }
 
 SDValue DAGTypeLegalizer::PromoteIntRes_BSWAP(SDNode *N) {
@@ -904,6 +913,7 @@ bool DAGTypeLegalizer::PromoteIntegerOperand(SDNode *N, unsigned OpNo) {
   case ISD::SRL:
   case ISD::ROTL:
   case ISD::ROTR: Res = PromoteIntOp_Shift(N); break;
+  case ISD::FREEZE: Res = PromoteIntOp_FREEZE(N); break;
   }
 
   // If the result is null, the sub-method took care of registering results etc.
@@ -1252,6 +1262,10 @@ SDValue DAGTypeLegalizer::PromoteIntOp_ZERO_EXTEND(SDNode *N) {
                                 N->getOperand(0).getValueType().getScalarType());
 }
 
+SDValue DAGTypeLegalizer::PromoteIntOp_FREEZE(SDNode *N) {
+  SDValue Op = GetPromotedInteger(N->getOperand(0));
+  return DAG.getNode(ISD::FREEZE, SDLoc(N), N->getValueType(0), Op);
+}
 
 //===----------------------------------------------------------------------===//
 //  Integer Result Expansion
@@ -1282,6 +1296,7 @@ void DAGTypeLegalizer::ExpandIntegerResult(SDNode *N, unsigned ResNo) {
   case ISD::SELECT:       SplitRes_SELECT(N, Lo, Hi); break;
   case ISD::SELECT_CC:    SplitRes_SELECT_CC(N, Lo, Hi); break;
   case ISD::UNDEF:        SplitRes_UNDEF(N, Lo, Hi); break;
+  case ISD::FREEZE:       SplitRes_FREEZE(N, Lo, Hi); break;
 
   case ISD::BITCAST:            ExpandRes_BITCAST(N, Lo, Hi); break;
   case ISD::BUILD_PAIR:         ExpandRes_BUILD_PAIR(N, Lo, Hi); break;
@@ -2747,6 +2762,7 @@ bool DAGTypeLegalizer::ExpandIntegerOperand(SDNode *N, unsigned OpNo) {
   case ISD::STORE:   Res = ExpandIntOp_STORE(cast<StoreSDNode>(N), OpNo); break;
   case ISD::TRUNCATE:          Res = ExpandIntOp_TRUNCATE(N); break;
   case ISD::UINT_TO_FP:        Res = ExpandIntOp_UINT_TO_FP(N); break;
+  case ISD::FREEZE:            Res = ExpandIntOp_FREEZE(N); break;
 
   case ISD::SHL:
   case ISD::SRA:
@@ -3197,6 +3213,11 @@ SDValue DAGTypeLegalizer::ExpandIntOp_ATOMIC_STORE(SDNode *N) {
   return Swap.getValue(1);
 }
 
+SDValue DAGTypeLegalizer::ExpandIntOp_FREEZE(SDNode *N) {
+  SDValue InL, InH;
+  GetExpandedInteger(N->getOperand(0), InL, InH);
+  return DAG.getNode(ISD::FREEZE, SDLoc(N), N->getValueType(0), InL);
+}
 
 SDValue DAGTypeLegalizer::PromoteIntRes_EXTRACT_SUBVECTOR(SDNode *N) {
   SDValue InOp0 = N->getOperand(0);

--- a/lib/CodeGen/SelectionDAG/LegalizeTypes.h
+++ b/lib/CodeGen/SelectionDAG/LegalizeTypes.h
@@ -255,6 +255,7 @@ private:
   SDValue PromoteIntRes_EXTRACT_VECTOR_ELT(SDNode *N);
   SDValue PromoteIntRes_FP_TO_XINT(SDNode *N);
   SDValue PromoteIntRes_FP_TO_FP16(SDNode *N);
+  SDValue PromoteIntRes_FREEZE(SDNode *N);
   SDValue PromoteIntRes_INT_EXTEND(SDNode *N);
   SDValue PromoteIntRes_LOAD(LoadSDNode *N);
   SDValue PromoteIntRes_MLOAD(MaskedLoadSDNode *N);
@@ -290,6 +291,7 @@ private:
   SDValue PromoteIntOp_INSERT_VECTOR_ELT(SDNode *N, unsigned OpNo);
   SDValue PromoteIntOp_EXTRACT_VECTOR_ELT(SDNode *N);
   SDValue PromoteIntOp_EXTRACT_SUBVECTOR(SDNode *N);
+  SDValue PromoteIntOp_FREEZE(SDNode *N);
   SDValue PromoteIntOp_CONCAT_VECTORS(SDNode *N);
   SDValue PromoteIntOp_SCALAR_TO_VECTOR(SDNode *N);
   SDValue PromoteIntOp_SELECT(SDNode *N, unsigned OpNo);
@@ -380,6 +382,7 @@ private:
   SDValue ExpandIntOp_UINT_TO_FP(SDNode *N);
   SDValue ExpandIntOp_RETURNADDR(SDNode *N);
   SDValue ExpandIntOp_ATOMIC_STORE(SDNode *N);
+  SDValue ExpandIntOp_FREEZE(SDNode *N);
 
   void IntegerExpandSetCCOperands(SDValue &NewLHS, SDValue &NewRHS,
                                   ISD::CondCode &CCCode, const SDLoc &dl);
@@ -809,6 +812,7 @@ private:
   void SplitRes_SELECT      (SDNode *N, SDValue &Lo, SDValue &Hi);
   void SplitRes_SELECT_CC   (SDNode *N, SDValue &Lo, SDValue &Hi);
   void SplitRes_UNDEF       (SDNode *N, SDValue &Lo, SDValue &Hi);
+  void SplitRes_FREEZE      (SDNode *N, SDValue &Lo, SDValue &Hi);
 
   //===--------------------------------------------------------------------===//
   // Generic Expansion: LegalizeTypesGeneric.cpp

--- a/lib/CodeGen/SelectionDAG/LegalizeTypesGeneric.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeTypesGeneric.cpp
@@ -553,3 +553,12 @@ void DAGTypeLegalizer::SplitRes_UNDEF(SDNode *N, SDValue &Lo, SDValue &Hi) {
   Lo = DAG.getUNDEF(LoVT);
   Hi = DAG.getUNDEF(HiVT);
 }
+
+void DAGTypeLegalizer::SplitRes_FREEZE(SDNode *N, SDValue &Lo, SDValue &Hi) {
+  SDValue L, H;
+  SDLoc dl(N);
+  GetSplitOp(N->getOperand(0), L, H);
+
+  Lo = DAG.getNode(ISD::FREEZE, dl, L.getValueType(), L);
+  Hi = DAG.getNode(ISD::FREEZE, dl, H.getValueType(), H);
+}

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -9348,5 +9348,9 @@ void SelectionDAGBuilder::visitSwitch(const SwitchInst &SI) {
 
 void SelectionDAGBuilder::visitFreeze(const FreezeInst &I) {
   SDValue N = getValue(I.getOperand(0));
-  setValue(&I, N);
+  SDLoc dl = getCurSDLoc();
+  EVT DestVT = DAG.getTargetLoweringInfo().getValueType(DAG.getDataLayout(),
+                                                        I.getType());
+
+  setValue(&I, DAG.getNode(ISD::FREEZE, dl, DestVT, N));
 }

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -9345,3 +9345,8 @@ void SelectionDAGBuilder::visitSwitch(const SwitchInst &SI) {
     lowerWorkItem(W, SI.getCondition(), SwitchMBB, DefaultMBB);
   }
 }
+
+void SelectionDAGBuilder::visitFreeze(const FreezeInst &I) {
+  SDValue N = getValue(I.getOperand(0));
+  setValue(&I, N);
+}

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.h
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.h
@@ -896,6 +896,7 @@ private:
   void visitAtomicStore(const StoreInst &I);
   void visitLoadFromSwiftError(const LoadInst &I);
   void visitStoreToSwiftError(const StoreInst &I);
+  void visitFreeze(const FreezeInst &I);
 
   void visitInlineAsm(ImmutableCallSite CS);
   const char *visitIntrinsicCall(const CallInst &I, unsigned Intrinsic);

--- a/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -298,6 +298,7 @@ std::string SDNode::getOperationName(const SelectionDAG *G) const {
   case ISD::GC_TRANSITION_START:        return "gc_transition.start";
   case ISD::GC_TRANSITION_END:          return "gc_transition.end";
   case ISD::GET_DYNAMIC_AREA_OFFSET:    return "get.dynamic.area.offset";
+  case ISD::FREEZE:                     return "freeze";
 
   // Bit manipulation
   case ISD::BITREVERSE:                 return "bitreverse";

--- a/lib/CodeGen/TargetLoweringBase.cpp
+++ b/lib/CodeGen/TargetLoweringBase.cpp
@@ -1744,6 +1744,7 @@ int TargetLoweringBase::InstructionOpcodeToISD(unsigned Opcode) const {
   case ExtractValue:   return ISD::MERGE_VALUES;
   case InsertValue:    return ISD::MERGE_VALUES;
   case LandingPad:     return 0;
+  case Freeze:         return 0;
   }
 
   llvm_unreachable("Unknown instruction type encountered!");

--- a/lib/CodeGen/TargetLoweringBase.cpp
+++ b/lib/CodeGen/TargetLoweringBase.cpp
@@ -1744,7 +1744,7 @@ int TargetLoweringBase::InstructionOpcodeToISD(unsigned Opcode) const {
   case ExtractValue:   return ISD::MERGE_VALUES;
   case InsertValue:    return ISD::MERGE_VALUES;
   case LandingPad:     return 0;
-  case Freeze:         return 0;
+  case Freeze:         return ISD::FREEZE;
   }
 
   llvm_unreachable("Unknown instruction type encountered!");

--- a/lib/IR/Core.cpp
+++ b/lib/IR/Core.cpp
@@ -3002,6 +3002,11 @@ LLVMValueRef LLVMBuildInsertValue(LLVMBuilderRef B, LLVMValueRef AggVal,
                                            Index, Name));
 }
 
+LLVMValueRef LLVMBuildFreeze(LLVMBuilderRef B, LLVMValueRef Val,
+                             const char *Name) {
+  return wrap(unwrap(B)->CreateFreeze(unwrap(Val), Name));
+}
+
 LLVMValueRef LLVMBuildIsNull(LLVMBuilderRef B, LLVMValueRef Val,
                              const char *Name) {
   return wrap(unwrap(B)->CreateIsNull(unwrap(Val), Name));

--- a/lib/IR/Instruction.cpp
+++ b/lib/IR/Instruction.cpp
@@ -319,6 +319,7 @@ const char *Instruction::getOpcodeName(unsigned OpCode) {
   case InsertValue:    return "insertvalue";
   case LandingPad:     return "landingpad";
   case CleanupPad:     return "cleanuppad";
+  case Freeze:         return "freeze";
 
   default: return "<Invalid operator> ";
   }

--- a/lib/IR/Instructions.cpp
+++ b/lib/IR/Instructions.cpp
@@ -3794,6 +3794,22 @@ void IndirectBrInst::setSuccessorV(unsigned idx, BasicBlock *B) {
 }
 
 //===----------------------------------------------------------------------===//
+//                            FreezeInst Implementation
+//===----------------------------------------------------------------------===//
+
+FreezeInst::FreezeInst(Value *S,
+                       const Twine &Name, Instruction *InsertBefore)
+    : UnaryInstruction(S->getType(), Freeze, S, InsertBefore) {
+  setName(Name);
+}
+
+FreezeInst::FreezeInst(Value *S,
+                       const Twine &Name, BasicBlock *InsertAtEnd)
+    : UnaryInstruction(S->getType(), Freeze, S, InsertAtEnd) {
+  setName(Name);
+}
+
+//===----------------------------------------------------------------------===//
 //                           cloneImpl() implementations
 //===----------------------------------------------------------------------===//
 
@@ -3994,4 +4010,8 @@ FuncletPadInst *FuncletPadInst::cloneImpl() const {
 UnreachableInst *UnreachableInst::cloneImpl() const {
   LLVMContext &Context = getContext();
   return new UnreachableInst(Context);
+}
+
+FreezeInst *FreezeInst::cloneImpl() const {
+  return new FreezeInst(getOperand(0));
 }

--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -474,6 +474,7 @@ private:
   void visitFuncletPadInst(FuncletPadInst &FPI);
   void visitCatchSwitchInst(CatchSwitchInst &CatchSwitch);
   void visitCleanupReturnInst(CleanupReturnInst &CRI);
+  void visitFreezeInst(FreezeInst &FI);
 
   void verifyCallSite(CallSite CS);
   void verifySwiftErrorCallSite(CallSite CS, const Value *SwiftErrorVal);
@@ -3648,6 +3649,13 @@ void Verifier::visitCleanupReturnInst(CleanupReturnInst &CRI) {
   }
 
   visitTerminatorInst(CRI);
+}
+
+void Verifier::visitFreezeInst(FreezeInst &FI) {
+  Assert(FI.getOperand(0)->getType()->isIntegerTy(),
+         "Cannot freeze non-integer type!", &FI);
+
+  visitInstruction(FI);
 }
 
 void Verifier::verifyDominatesUse(Instruction &I, unsigned i) {

--- a/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -279,6 +279,7 @@ public:
   Instruction *visitSelectInst(SelectInst &SI);
   Instruction *visitCallInst(CallInst &CI);
   Instruction *visitInvokeInst(InvokeInst &II);
+  Instruction *visitFreeze(FreezeInst &FI);
 
   Instruction *SliceUpIllegalIntegerPHI(PHINode &PN);
   Instruction *visitPHINode(PHINode &PN);

--- a/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2773,6 +2773,15 @@ Instruction *InstCombiner::visitLandingPadInst(LandingPadInst &LI) {
   return nullptr;
 }
 
+Instruction *InstCombiner::visitFreeze(FreezeInst &FI) {
+  Value *Op0 = FI.getOperand(0);
+
+  if (Value *V = SimplifyFreezeInst(Op0, DL, &TLI, &DT, &AC))
+    return replaceInstUsesWith(FI, V);
+
+  return nullptr;
+}
+
 /// Try to move the specified instruction from its current block into the
 /// beginning of DestBlock, which can only happen if it's safe to move the
 /// instruction past all of the instructions between it and the end of its

--- a/lib/Transforms/Scalar/LoopUnswitch.cpp
+++ b/lib/Transforms/Scalar/LoopUnswitch.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Analysis/BlockFrequencyInfoImpl.h"
 #include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/BranchProbabilityInfo.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Support/BranchProbability.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -623,6 +624,56 @@ bool LoopUnswitch::processCurrentLoop() {
         !isGuaranteedToExecute(*TI, DT, currentLoop, &SafetyInfo))
       continue;
 
+    // Do we need to freeze condition of TI?
+    // Here we use simple heuristic : 
+    // If TI is in header, and all instructions
+    // between header beginning and TI are guaranteed to transfer execution
+    // to successor, then don't freeze.
+    bool NeedFreeze = true;
+    {
+      bool UnconditionallyGotoTI = true;
+      BasicBlock *BB = currentLoop->getHeader();
+      while (BB) {
+        TerminatorInst *BBTI = BB->getTerminator();
+        if (BBTI == TI)
+          // There's a unique path from header to TI
+          break;
+        else if (BBTI->getNumSuccessors() == 1)
+          BB = BBTI->getSuccessor(0);
+        else {
+          BB = nullptr;
+          UnconditionallyGotoTI = false;
+        }
+      }
+      if (UnconditionallyGotoTI) {
+        // Now we check whether all instructions from header to
+        // TI guarantees to transfer execution to successor.
+        NeedFreeze = false;
+        BB = currentLoop->getHeader();
+        while (BB) {
+          for (auto &I : *BB) {
+            Instruction *Inst = &I;
+            if (!isGuaranteedToTransferExecutionToSuccessor(Inst)) {
+              NeedFreeze = true;
+              break;
+            }
+          }
+          if (NeedFreeze)
+            break;
+
+          TerminatorInst *BBTI = BB->getTerminator();
+          if (BBTI == TI)
+            // There's a unique path from header to TI
+            break;
+          else {
+            assert (BBTI->getNumSuccessors() == 1 &&
+                    "Should have no more than 1 successors");
+            BB = BBTI->getSuccessor(0);
+          }
+        }
+      }
+    }
+
     if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
       // Some branches may be rendered unreachable because of previous
       // unswitching.
@@ -637,8 +688,10 @@ bool LoopUnswitch::processCurrentLoop() {
         // unswitch on it if we desire.
         Value *LoopCond = FindLIVLoopCondition(BI->getCondition(),
                                                currentLoop, Changed);
+        // Determine whether we should freeze the condition.
         if (LoopCond &&
-            UnswitchIfProfitable(LoopCond, ConstantInt::getTrue(Context), true, TI)) {
+            UnswitchIfProfitable(LoopCond, ConstantInt::getTrue(Context),
+                                 NeedFreeze, TI)) {
           ++NumBranches;
           return true;
         }
@@ -668,7 +721,7 @@ bool LoopUnswitch::processCurrentLoop() {
         if (!UnswitchVal)
           continue;
 
-        if (UnswitchIfProfitable(LoopCond, UnswitchVal, true)) {
+        if (UnswitchIfProfitable(LoopCond, UnswitchVal, NeedFreeze)) {
           ++NumSwitches;
           return true;
         }
@@ -910,6 +963,11 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
   // this scenario could be very common in practice.
   SmallSet<BasicBlock*, 8> Visited;
 
+  // If there exists an instruction I which is (1) between the beginning of
+  // the loop preheader and the branch to unswitch, and (1) not guaranteed to 
+  // transfer execution to successor, then we need to freeze the condition.
+  bool NeedFreeze = false;
+
   while (true) {
     // If we exit loop or reach a previous visited block, then
     // we can not reach any trivial condition candidates (unfoldable
@@ -921,9 +979,16 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
     // Check if this loop will execute any side-effecting instructions (e.g.
     // stores, calls, volatile loads) in the part of the loop that the code
     // *would* execute. Check the header first.
-    for (Instruction &I : *CurrentBB)
+    for (Instruction &I : *CurrentBB) {
       if (I.mayHaveSideEffects())
         return false;
+      if (!NeedFreeze &&
+          isGuaranteedToTransferExecutionToSuccessor(&I)) {
+        // There exists an instruction which can exit from the loop.
+        // Hoisting branch must not have undef/poison value as its condition.
+        NeedFreeze = true;
+      }
+    }
 
     // FIXME: add check for constant foldable switch instructions.
     if (BranchInst *BI = dyn_cast<BranchInst>(CurrentTerm)) {
@@ -980,7 +1045,7 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
       return false;   // Can't handle this.
 
     UnswitchTrivialCondition(currentLoop, LoopCond, CondVal, LoopExitBB,
-                             true, CurrentTerm);
+                             NeedFreeze, CurrentTerm);
     ++NumBranches;
     return true;
   } else if (SwitchInst *SI = dyn_cast<SwitchInst>(CurrentTerm)) {
@@ -1023,7 +1088,7 @@ bool LoopUnswitch::TryTrivialLoopUnswitch(bool &Changed) {
       return false;   // Can't handle this.
 
     UnswitchTrivialCondition(currentLoop, LoopCond, CondVal, LoopExitBB,
-                             true, nullptr);
+                             NeedFreeze, nullptr);
     ++NumSwitches;
     return true;
   }

--- a/test/Bitcode/freeze.ll
+++ b/test/Bitcode/freeze.ll
@@ -1,0 +1,11 @@
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+
+define i32 @f(i32 %x) {
+  %y = freeze i32 %x
+  ret i32 %y
+}
+
+; CHECK:      define i32 @f(i32 %x) {
+; CHECK-NEXT:   %y = freeze i32 %x
+; CHECK-NEXT:   ret i32 %y
+; CHECK-NEXT: }

--- a/test/CodeGen/X86/freeze-legalize-split.ll
+++ b/test/CodeGen/X86/freeze-legalize-split.ll
@@ -1,0 +1,18 @@
+; Make sure that seldag legalization works correctly for freeze instruction.
+; RUN: llc -march=x86 < %s 2>&1 | FileCheck %s
+
+; CHECK: movl    $303174162, %ecx 
+; CHECK: movl    $875836468, %esi 
+; CHECK: movl    $1448498774, %edx
+; CHECK: movl    $2021161080, %eax
+; CHECK: xorl    %esi, %eax
+; CHECK: xorl    %ecx, %edx
+; CHECK: popl    %esi
+; CHECK: retl
+
+define i64 @foo(i32 %x) {
+  %y1 = freeze i64 1302123111658042420 ; 0x1212121234343434
+  %y2 = freeze i64 6221254864647256184 ; 0x5656565678787878
+  %t2 = xor i64 %y1, %y2
+  ret i64 %t2
+}

--- a/test/CodeGen/X86/freeze.ll
+++ b/test/CodeGen/X86/freeze.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -print-machineinstrs=expand-isel-pseudos %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MCINSTR
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu < %s 2>&1 | FileCheck %s --check-prefix=X86ASM
+
+; X86ASM: imull   %eax, %eax
+; X86ASM: xorl    %eax, %eax
+; X86ASM: retq
+
+; MCINSTR: %vreg1<def> = IMPLICIT_DEF; GR32:%vreg1
+; MCINSTR: %vreg2<def,tied1> = IMUL32rr %vreg1<tied0>, %vreg1, %EFLAGS<imp-def,dead>; GR32:%vreg2,%vreg1,%vreg1
+; MCINSTR: %vreg3<def,tied1> = XOR32rr %vreg2<tied0>, %vreg1, %EFLAGS<imp-def,dead>; GR32:%vreg3,%vreg2,%vreg1
+; MCINSTR: %EAX<def> = COPY %vreg3; GR32:%vreg3
+; MCINSTR: RET 0, %EAX
+
+define i32 @foo(i32 %x) {
+  %y1 = freeze i32 undef
+  %t1 = mul i32 %y1, %y1
+  %t2 = xor i32 %t1, %y1
+  ret i32 %t2
+}

--- a/test/Transforms/InstCombine/freeze.ll
+++ b/test/Transforms/InstCombine/freeze.ll
@@ -1,0 +1,15 @@
+; RUN: opt < %s -instcombine -S | FileCheck --match-full-lines %s
+
+define i32 @fold(i32 %x) {
+; CHECK: %y = freeze i32 %x
+; CHECK-NEXT: ret i32 %y
+  %y = freeze i32 %x
+  %z = freeze i32 %y
+  ret i32 %z
+}
+
+define i32 @make_const() {
+; CHECK: ret i32 10
+  %x = freeze i32 10
+  ret i32 %x
+}

--- a/test/Transforms/LoopUnswitch/2011-11-18-SimpleSwitch.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-SimpleSwitch.ll
@@ -5,7 +5,9 @@
 ; STATS: 1 loop-simplify - Number of pre-header or exit blocks inserted
 ; STATS: 2 loop-unswitch - Number of switches unswitched
 
-; CHECK:      %1 = icmp eq i32 %c, 1
+; CHECK:      %c.fr = freeze i32 %c
+; CHECK-NEXT: %c.fr.fr = freeze i32 %c.fr
+; CHECK-NEXT: %1 = icmp eq i32 %c.fr.fr, 1
 ; CHECK-NEXT: br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -24,7 +26,7 @@
 ; CHECK-NEXT:   br label %loop_begin.backedge.us
 
 ; CHECK:      .split:                                           ; preds = %..split_crit_edge
-; CHECK-NEXT:   %2 = icmp eq i32 %c, 2
+; CHECK-NEXT:   %2 = icmp eq i32 %c.fr.fr, 2
 ; CHECK-NEXT:   br i1 %2, label %.split.split.us, label %.split..split.split_crit_edge
 
 ; CHECK:      .split..split.split_crit_edge:                    ; preds = %.split
@@ -49,7 +51,7 @@
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split.split
 ; CHECK-NEXT:   %var_val = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c, label %default.us-lcssa.us-lcssa [
+; CHECK-NEXT:   switch i32 %c.fr.fr, label %default.us-lcssa.us-lcssa [
 ; CHECK-NEXT:     i32 1, label %inc
 ; CHECK-NEXT:     i32 2, label %dec
 ; CHECK-NEXT:   ]

--- a/test/Transforms/LoopUnswitch/2011-11-18-SimpleSwitch.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-SimpleSwitch.ll
@@ -5,9 +5,7 @@
 ; STATS: 1 loop-simplify - Number of pre-header or exit blocks inserted
 ; STATS: 2 loop-unswitch - Number of switches unswitched
 
-; CHECK:      %c.fr = freeze i32 %c
-; CHECK-NEXT: %c.fr.fr = freeze i32 %c.fr
-; CHECK-NEXT: %1 = icmp eq i32 %c.fr.fr, 1
+; CHECK:      %1 = icmp eq i32 %c, 1
 ; CHECK-NEXT: br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -26,7 +24,7 @@
 ; CHECK-NEXT:   br label %loop_begin.backedge.us
 
 ; CHECK:      .split:                                           ; preds = %..split_crit_edge
-; CHECK-NEXT:   %2 = icmp eq i32 %c.fr.fr, 2
+; CHECK-NEXT:   %2 = icmp eq i32 %c, 2
 ; CHECK-NEXT:   br i1 %2, label %.split.split.us, label %.split..split.split_crit_edge
 
 ; CHECK:      .split..split.split_crit_edge:                    ; preds = %.split
@@ -51,7 +49,7 @@
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split.split
 ; CHECK-NEXT:   %var_val = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c.fr.fr, label %default.us-lcssa.us-lcssa [
+; CHECK-NEXT:   switch i32 %c, label %default.us-lcssa.us-lcssa [
 ; CHECK-NEXT:     i32 1, label %inc
 ; CHECK-NEXT:     i32 2, label %dec
 ; CHECK-NEXT:   ]

--- a/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches-Threshold.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches-Threshold.ll
@@ -7,9 +7,7 @@
 
 ; ModuleID = '../llvm/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll'
 
-; CHECK:        %c.fr = freeze i32 %c
-
-; CHECK:        %1 = icmp eq i32 %c.fr, 1
+; CHECK:        %1 = icmp eq i32 %c, 1
 ; CHECK-NEXT:   br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -35,7 +33,7 @@
 ; CHECK-NEXT:   br label %loop_begin
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split
-; CHECK:        switch i32 %c.fr, label %second_switch [
+; CHECK:        switch i32 %c, label %second_switch [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge
 ; CHECK-NEXT:   ]
 

--- a/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches-Threshold.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches-Threshold.ll
@@ -7,7 +7,9 @@
 
 ; ModuleID = '../llvm/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll'
 
-; CHECK:        %1 = icmp eq i32 %c, 1
+; CHECK:        %c.fr = freeze i32 %c
+
+; CHECK:        %1 = icmp eq i32 %c.fr, 1
 ; CHECK-NEXT:   br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -33,7 +35,7 @@
 ; CHECK-NEXT:   br label %loop_begin
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split
-; CHECK:        switch i32 %c, label %second_switch [
+; CHECK:        switch i32 %c.fr, label %second_switch [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge
 ; CHECK-NEXT:   ]
 

--- a/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll
@@ -5,11 +5,9 @@
 ; STATS: 1 loop-simplify - Number of pre-header or exit blocks inserted
 ; STATS: 3 loop-unswitch - Number of switches unswitched
 
-; CHECK:        %c.fr = freeze i32 %c
-
 ; CHECK:        %d.fr = freeze i32 %d
 ; CHECK-NEXT:   %d.fr.fr = freeze i32 %d.fr
-; CHECK-NEXT:   %1 = icmp eq i32 %c.fr, 1
+; CHECK-NEXT:   %1 = icmp eq i32 %c, 1
 ; CHECK-NEXT:   br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
@@ -70,7 +68,7 @@
 
 ; CHECK:      loop_begin.us1:                                   ; preds = %loop_begin.backedge.us6, %.split.split.us
 ; CHECK-NEXT:   %var_val.us2 = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c.fr, label %second_switch.us3 [
+; CHECK-NEXT:   switch i32 %c, label %second_switch.us3 [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge.us
 ; CHECK-NEXT:   ]
 
@@ -91,7 +89,7 @@
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split.split
 ; CHECK-NEXT:   %var_val = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c.fr, label %second_switch [
+; CHECK-NEXT:   switch i32 %c, label %second_switch [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge
 ; CHECK-NEXT:   ]
 

--- a/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll
+++ b/test/Transforms/LoopUnswitch/2011-11-18-TwoSwitches.ll
@@ -5,14 +5,18 @@
 ; STATS: 1 loop-simplify - Number of pre-header or exit blocks inserted
 ; STATS: 3 loop-unswitch - Number of switches unswitched
 
-; CHECK:        %1 = icmp eq i32 %c, 1
+; CHECK:        %c.fr = freeze i32 %c
+
+; CHECK:        %d.fr = freeze i32 %d
+; CHECK-NEXT:   %d.fr.fr = freeze i32 %d.fr
+; CHECK-NEXT:   %1 = icmp eq i32 %c.fr, 1
 ; CHECK-NEXT:   br i1 %1, label %.split.us, label %..split_crit_edge
 
 ; CHECK:      ..split_crit_edge:                                ; preds = %0
 ; CHECK-NEXT:   br label %.split
 
 ; CHECK:      .split.us:                                        ; preds = %0
-; CHECK-NEXT:   %2 = icmp eq i32 %d, 1
+; CHECK-NEXT:   %2 = icmp eq i32 %d.fr.fr, 1
 ; CHECK-NEXT:   br i1 %2, label %.split.us.split.us, label %.split.us..split.us.split_crit_edge
 
 ; CHECK:      .split.us..split.us.split_crit_edge:              ; preds = %.split.us
@@ -43,7 +47,7 @@
 ; CHECK-NEXT:     i32 1, label %inc.us
 
 ; CHECK:      second_switch.us:                                 ; preds = %loop_begin.us
-; CHECK-NEXT:   switch i32 %d, label %default.us [
+; CHECK-NEXT:   switch i32 %d.fr.fr, label %default.us [
 ; CHECK-NEXT:     i32 1, label %second_switch.us.inc.us_crit_edge
 ; CHECK-NEXT:   ]
 
@@ -55,7 +59,7 @@
 ; CHECK-NEXT:   br label %loop_begin.backedge.us
 
 ; CHECK:      .split:                                           ; preds = %..split_crit_edge
-; CHECK-NEXT:   %3 = icmp eq i32 %d, 1
+; CHECK-NEXT:   %3 = icmp eq i32 %d.fr.fr, 1
 ; CHECK-NEXT:   br i1 %3, label %.split.split.us, label %.split..split.split_crit_edge
 
 ; CHECK:      .split..split.split_crit_edge:                    ; preds = %.split
@@ -66,7 +70,7 @@
 
 ; CHECK:      loop_begin.us1:                                   ; preds = %loop_begin.backedge.us6, %.split.split.us
 ; CHECK-NEXT:   %var_val.us2 = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c, label %second_switch.us3 [
+; CHECK-NEXT:   switch i32 %c.fr, label %second_switch.us3 [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge.us
 ; CHECK-NEXT:   ]
 
@@ -87,7 +91,7 @@
 
 ; CHECK:      loop_begin:                                       ; preds = %loop_begin.backedge, %.split.split
 ; CHECK-NEXT:   %var_val = load i32, i32* %var
-; CHECK-NEXT:   switch i32 %c, label %second_switch [
+; CHECK-NEXT:   switch i32 %c.fr, label %second_switch [
 ; CHECK-NEXT:     i32 1, label %loop_begin.inc_crit_edge
 ; CHECK-NEXT:   ]
 
@@ -95,7 +99,7 @@
 ; CHECK-NEXT:   br i1 true, label %us-unreachable.us-lcssa, label %inc
 
 ; CHECK:      second_switch:                                    ; preds = %loop_begin
-; CHECK-NEXT:   switch i32 %d, label %default [
+; CHECK-NEXT:   switch i32 %d.fr.fr, label %default [
 ; CHECK-NEXT:     i32 1, label %second_switch.inc_crit_edge
 ; CHECK-NEXT:   ]
 

--- a/test/Transforms/LoopUnswitch/2015-06-17-Metadata.ll
+++ b/test/Transforms/LoopUnswitch/2015-06-17-Metadata.ll
@@ -16,7 +16,8 @@ for.body:                                         ; preds = %for.inc, %for.body.
   %cmp1 = icmp eq i32 %a, 12345
   br i1 %cmp1, label %if.then, label %if.else, !prof !0
 ; CHECK: %cmp1 = icmp eq i32 %a, 12345
-; CHECK-NEXT: br i1 %cmp1, label %for.body.us, label %for.body, !prof !0
+; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
+; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.us, label %for.body, !prof !0
 if.then:                                          ; preds = %for.body
 ; CHECK: for.body.us:
 ; CHECK: add nsw i32 %{{.*}}, 123
@@ -53,7 +54,8 @@ entry:
   br label %for.body
 ;CHECK: entry:
 ;CHECK-NEXT: %cmp1 = icmp eq i32 1, 2
-;CHECK-NEXT: br i1 %cmp1, label %for.body, label %for.cond.cleanup.split, !prof !1
+;CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
+;CHECK-NEXT: br i1 %cmp1.fr, label %for.body, label %for.cond.cleanup.split, !prof !1
 ;CHECK: for.body:
 for.body:                                         ; preds = %for.inc, %entry
   %inc.i = phi i32 [ 0, %entry ], [ %inc, %if.then ]

--- a/test/Transforms/LoopUnswitch/2015-06-17-Metadata.ll
+++ b/test/Transforms/LoopUnswitch/2015-06-17-Metadata.ll
@@ -16,8 +16,7 @@ for.body:                                         ; preds = %for.inc, %for.body.
   %cmp1 = icmp eq i32 %a, 12345
   br i1 %cmp1, label %if.then, label %if.else, !prof !0
 ; CHECK: %cmp1 = icmp eq i32 %a, 12345
-; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
-; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.us, label %for.body, !prof !0
+; CHECK-NEXT: br i1 %cmp1, label %for.body.us, label %for.body, !prof !0
 if.then:                                          ; preds = %for.body
 ; CHECK: for.body.us:
 ; CHECK: add nsw i32 %{{.*}}, 123

--- a/test/Transforms/LoopUnswitch/copy-metadata.ll
+++ b/test/Transforms/LoopUnswitch/copy-metadata.ll
@@ -3,7 +3,8 @@
 ; This test checks if unswitched condition preserve make.implicit metadata.
 
 define i32 @test(i1 %cond) {
-; CHECK: br i1 %cond, label %..split_crit_edge, label %.loop_exit.split_crit_edge, !make.implicit !0
+; CHECK: %cond.fr = freeze i1 %cond
+; CHECK: br i1 %cond.fr, label %..split_crit_edge, label %.loop_exit.split_crit_edge, !make.implicit !0
   br label %loop_begin
 
 loop_begin:

--- a/test/Transforms/LoopUnswitch/freeze.ll
+++ b/test/Transforms/LoopUnswitch/freeze.ll
@@ -1,4 +1,5 @@
-; 6 test cases which must introduce a freeze instruction after loop unswitch
+; 4 Test cases which must introduce a freeze instruction after loop unswitch
+; , and 2 test cases which must not introduce a freeze instruction
 ; RUN: opt < %s -loop-simplify -loop-rotate -loop-unswitch -S | FileCheck %s
 
 @x = common global i32 0, align 4
@@ -259,8 +260,7 @@ entry:
   br label %for.cond
 
 ; CHECK: %cmp1 = icmp eq i32 %b, 0
-; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
-; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+; CHECK-NEXT: br i1 %cmp1, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
 
 for.cond:                                         ; preds = %for.inc, %entry
   %sum.0 = phi i32 [ 0, %entry ], [ %sum.1, %for.inc ]
@@ -309,8 +309,7 @@ entry:
   br label %for.cond
 
 ; CHECK: %cmp1 = icmp eq i32 %b, 0
-; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
-; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+; CHECK-NEXT: br i1 %cmp1, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
 
 for.cond:                                         ; preds = %for.inc, %entry
   %sum.0 = phi i32 [ 0, %entry ], [ %sum.1, %for.inc ]

--- a/test/Transforms/LoopUnswitch/freeze.ll
+++ b/test/Transforms/LoopUnswitch/freeze.ll
@@ -1,0 +1,348 @@
+; 6 test cases which must introduce a freeze instruction after loop unswitch
+; RUN: opt < %s -loop-simplify -loop-rotate -loop-unswitch -S | FileCheck %s
+
+@x = common global i32 0, align 4
+define i32 @emptyf()  {
+entry:
+  ret i32 0
+}
+declare i32 @g(i32) 
+declare i32 @h(i32) 
+
+; int f_freeze1(int a, int b){
+;   int sum = 0;
+;   for(int i = 0; i < a; i++){
+;     g(0);
+;     if(b == 0){
+;       sum += g(i);
+;     }
+;     sum++;
+;   }
+;   return sum;
+; }
+
+; CHECK: define i32 @f_freeze1(i32 %a, i32 %b) {
+define i32 @f_freeze1(i32 %a, i32 %b)  {
+entry:
+  br label %for.cond
+
+; CHECK:       %cmp1 = icmp eq i32 %b, 0
+; CHECK-NEXT:  %cmp1.fr = freeze i1 %cmp1
+; CHECK-NEXT:  br i1 %cmp1.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %sum.0 = phi i32 [ 0, %entry ], [ %inc, %for.inc ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc3, %for.inc ]
+  %cmp = icmp slt i32 %i.0, %a
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %call = call i32 @g(i32 0)
+  %cmp1 = icmp eq i32 %b, 0
+  br i1 %cmp1, label %if.then, label %if.end
+
+if.then:                                          ; preds = %for.body
+  %call2 = call i32 @g(i32 %i.0)
+  %add = add nsw i32 %sum.0, %call2
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %for.body
+  %sum.1 = phi i32 [ %add, %if.then ], [ %sum.0, %for.body ]
+  %inc = add nsw i32 %sum.1, 1
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end
+  %inc3 = add nsw i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 %sum.0
+}
+
+; int f_freeze2(int a, int b){
+;   int sum = 0;
+;   for(int i = 0; i < a; i++){
+;     g(0);
+;     if(b == 0){
+;       sum += g(i);
+;     }else{
+;       sum += h(i);
+;     }
+;   }
+;   return sum;
+; }
+
+; CHECK: define i32 @f_freeze2(i32 %a, i32 %b) {
+define i32 @f_freeze2(i32 %a, i32 %b)  {
+entry:
+  br label %for.cond
+
+; CHECK:       %cmp1 = icmp eq i32 %b, 0
+; CHECK-NEXT:  %cmp1.fr = freeze i1 %cmp1
+; CHECK-NEXT:  br i1 %cmp1.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %sum.0 = phi i32 [ 0, %entry ], [ %sum.1, %for.inc ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc, %for.inc ]
+  %cmp = icmp slt i32 %i.0, %a
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %call = call i32 @g(i32 0)
+  %cmp1 = icmp eq i32 %b, 0
+  br i1 %cmp1, label %if.then, label %if.else
+
+if.then:                                          ; preds = %for.body
+  %call2 = call i32 @g(i32 %i.0)
+  %add = add nsw i32 %sum.0, %call2
+  br label %if.end
+
+if.else:                                          ; preds = %for.body
+  %call3 = call i32 @h(i32 %i.0)
+  %add4 = add nsw i32 %sum.0, %call3
+  br label %if.end
+
+if.end:                                           ; preds = %if.else, %if.then
+  %sum.1 = phi i32 [ %add, %if.then ], [ %add4, %if.else ]
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end
+  %inc = add nsw i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 %sum.0
+}
+
+
+; int f_freeze3(int a, int b){
+;   int sum = 0;
+;   for(int i = 0; i < a; i++){
+;     if(x == 0) {
+;       emptyf();
+;     }
+;     // Unswitching the below branch
+;     if(b == 0){
+;       sum += g(i);
+;     }
+;     sum++;
+;   }
+;   return sum;
+; }
+
+; CHECK: define i32 @f_freeze3(i32 %a, i32 %b) {
+define i32 @f_freeze3(i32 %a, i32 %b)  {
+entry:
+  br label %for.cond
+
+; CHECK:       %cmp2 = icmp eq i32 %b, 0
+; CHECK-NEXT:  %cmp2.fr = freeze i1 %cmp2
+; CHECK-NEXT:  br i1 %cmp2.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %sum.0 = phi i32 [ 0, %entry ], [ %inc, %for.inc ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc6, %for.inc ]
+  %cmp = icmp slt i32 %i.0, %a
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %0 = load i32, i32* @x, align 4
+  %cmp1 = icmp eq i32 %0, 0
+  br i1 %cmp1, label %if.then, label %if.end
+
+if.then:                                          ; preds = %for.body
+  %call = call i32 @emptyf()
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %for.body
+  %cmp2 = icmp eq i32 %b, 0
+  br i1 %cmp2, label %if.then3, label %if.end5
+
+if.then3:                                         ; preds = %if.end
+  %call4 = call i32 @g(i32 %i.0)
+  %add = add nsw i32 %sum.0, %call4
+  br label %if.end5
+
+if.end5:                                          ; preds = %if.then3, %if.end
+  %sum.1 = phi i32 [ %add, %if.then3 ], [ %sum.0, %if.end ]
+  %inc = add nsw i32 %sum.1, 1
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end5
+  %inc6 = add nsw i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 %sum.0
+}
+
+; int f_freeze4(int a, int b){
+;   int sum = 0;
+;   for(int i = 0; i < a; i++){
+;     if(x == 0) {
+;       emptyf();
+;     }
+;     // Unswitching the below branch
+;     if(b == 0){
+;       sum += g(i);
+;     }else{
+;       sum += h(i);
+;     }
+;   }
+;   return sum;
+; }
+
+; CHECK: define i32 @f_freeze4(i32 %a, i32 %b) {
+define i32 @f_freeze4(i32 %a, i32 %b)  {
+entry:
+  br label %for.cond
+
+; CHECK:       %cmp2 = icmp eq i32 %b, 0
+; CHECK-NEXT:  %cmp2.fr = freeze i1 %cmp2
+; CHECK-NEXT:  br i1 %cmp2.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %sum.0 = phi i32 [ 0, %entry ], [ %sum.1, %for.inc ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc, %for.inc ]
+  %cmp = icmp slt i32 %i.0, %a
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %0 = load i32, i32* @x, align 4
+  %cmp1 = icmp eq i32 %0, 0
+  br i1 %cmp1, label %if.then, label %if.end
+
+if.then:                                          ; preds = %for.body
+  %call = call i32 @emptyf()
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %for.body
+  %cmp2 = icmp eq i32 %b, 0
+  br i1 %cmp2, label %if.then3, label %if.else
+
+if.then3:                                         ; preds = %if.end
+  %call4 = call i32 @g(i32 %i.0)
+  %add = add nsw i32 %sum.0, %call4
+  br label %if.end7
+
+if.else:                                          ; preds = %if.end
+  %call5 = call i32 @h(i32 %i.0)
+  %add6 = add nsw i32 %sum.0, %call5
+  br label %if.end7
+
+if.end7:                                          ; preds = %if.else, %if.then3
+  %sum.1 = phi i32 [ %add, %if.then3 ], [ %add6, %if.else ]
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end7
+  %inc = add nsw i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 %sum.0
+}
+
+; int f_freeze5(int a, int b){
+;   int sum = 0;
+;   for(int i = 0; i < a; i++){
+;     sum++;
+;     if(b == 0){
+;       sum += g(i);
+;     }
+;   }
+;   return sum;
+; }
+
+; CHECK: define i32 @f_freeze5(i32 %a, i32 %b) {
+define i32 @f_freeze5(i32 %a, i32 %b)  {
+entry:
+  br label %for.cond
+
+; CHECK: %cmp1 = icmp eq i32 %b, 0
+; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
+; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %sum.0 = phi i32 [ 0, %entry ], [ %sum.1, %for.inc ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc2, %for.inc ]
+  %cmp = icmp slt i32 %i.0, %a
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %inc = add nsw i32 %sum.0, 1
+  %cmp1 = icmp eq i32 %b, 0
+  br i1 %cmp1, label %if.then, label %if.end
+
+if.then:                                          ; preds = %for.body
+  %call = call i32 @g(i32 %i.0)
+  %add = add nsw i32 %inc, %call
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %for.body
+  %sum.1 = phi i32 [ %add, %if.then ], [ %inc, %for.body ]
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end
+  %inc2 = add nsw i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 %sum.0
+}
+
+; int f_freeze6(int a, int b){
+;   int sum = 0;
+;   for(int i = 0; i < a; i++){
+;     sum++;
+;     if(b == 0){
+;       sum += g(i);
+;     }else{
+;       sum += h(i);
+;     }
+;   }
+;   return sum;
+; }
+
+; CHECK: define i32 @f_freeze6(i32 %a, i32 %b) {
+define i32 @f_freeze6(i32 %a, i32 %b)  {
+entry:
+  br label %for.cond
+
+; CHECK: %cmp1 = icmp eq i32 %b, 0
+; CHECK-NEXT: %cmp1.fr = freeze i1 %cmp1
+; CHECK-NEXT: br i1 %cmp1.fr, label %for.body.lr.ph.split.us, label %for.body.lr.ph.for.body.lr.ph.split_crit_edge
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %sum.0 = phi i32 [ 0, %entry ], [ %sum.1, %for.inc ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc4, %for.inc ]
+  %cmp = icmp slt i32 %i.0, %a
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %inc = add nsw i32 %sum.0, 1
+  %cmp1 = icmp eq i32 %b, 0
+  br i1 %cmp1, label %if.then, label %if.else
+
+if.then:                                          ; preds = %for.body
+  %call = call i32 @g(i32 %i.0)
+  %add = add nsw i32 %inc, %call
+  br label %if.end
+
+if.else:                                          ; preds = %for.body
+  %call2 = call i32 @h(i32 %i.0)
+  %add3 = add nsw i32 %inc, %call2
+  br label %if.end
+
+if.end:                                           ; preds = %if.else, %if.then
+  %sum.1 = phi i32 [ %add, %if.then ], [ %add3, %if.else ]
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end
+  %inc4 = add nsw i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 %sum.0
+}
+
+

--- a/test/Transforms/LoopUnswitch/infinite-loop.ll
+++ b/test/Transforms/LoopUnswitch/infinite-loop.ll
@@ -13,10 +13,12 @@
 
 ; CHECK-LABEL: @func_16(
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: br i1 %a, label %entry.split, label %abort0.split
+; CHECK-NEXT: %b.fr = freeze i1 %b
+; CHECK-NEXT: %a.fr = freeze i1 %a
+; CHECK-NEXT: br i1 %a.fr, label %entry.split, label %abort0.split
 
 ; CHECK: entry.split:
-; CHECK-NEXT: br i1 %b, label %for.body, label %abort1.split
+; CHECK-NEXT: br i1 %b.fr, label %for.body, label %abort1.split
 
 ; CHECK: for.body:
 ; CHECK-NEXT: br label %for.body

--- a/test/Transforms/LoopUnswitch/msan.ll
+++ b/test/Transforms/LoopUnswitch/msan.ll
@@ -122,7 +122,8 @@ define void @must_execute(i1 zeroext %x, i32 %p, i32 %q) sanitize_memory {
 entry:
 ; CHECK:       %[[Y:.*]] = load i64, i64* @y, align 8
 ; CHECK-NEXT:  %[[YB:.*]] = icmp eq i64 %[[Y]], 0
-; CHECK-NEXT:  br i1 %[[YB]],
+; CHECK-NEXT:  %[[YB]].fr = freeze i1 %[[YB]]
+; CHECK-NEXT:  br i1 %[[YB]].fr,
 
   %x2 = alloca i8, align 1
   %frombool1 = zext i1 %x to i8

--- a/test/Transforms/LoopUnswitch/msan.ll
+++ b/test/Transforms/LoopUnswitch/msan.ll
@@ -122,8 +122,7 @@ define void @must_execute(i1 zeroext %x, i32 %p, i32 %q) sanitize_memory {
 entry:
 ; CHECK:       %[[Y:.*]] = load i64, i64* @y, align 8
 ; CHECK-NEXT:  %[[YB:.*]] = icmp eq i64 %[[Y]], 0
-; CHECK-NEXT:  %[[YB]].fr = freeze i1 %[[YB]]
-; CHECK-NEXT:  br i1 %[[YB]].fr,
+; CHECK-NEXT:  br i1 %[[YB]],
 
   %x2 = alloca i8, align 1
   %frombool1 = zext i1 %x to i8

--- a/test/Transforms/LoopUnswitch/trivial-unswitch.ll
+++ b/test/Transforms/LoopUnswitch/trivial-unswitch.ll
@@ -5,13 +5,15 @@
 ; after unswitching the first one.
 
 
-; CHECK:  br i1 %cond1, label %..split_crit_edge, label %.loop_exit.split_crit_edge
+; CHECK:  %cond2.fr = freeze i1 %cond2
+; CHECK:  %cond1.fr = freeze i1 %cond1
+; CHECK:  br i1 %cond1.fr, label %..split_crit_edge, label %.loop_exit.split_crit_edge
 
 ; CHECK:  ..split_crit_edge:                                ; preds = %0
 ; CHECK:    br label %.split
 
 ; CHECK:  .split:                                           ; preds = %..split_crit_edge
-; CHECK:    br i1 %cond2, label %.split..split.split_crit_edge, label %.split.loop_exit.split1_crit_edge
+; CHECK:    br i1 %cond2.fr, label %.split..split.split_crit_edge, label %.split.loop_exit.split1_crit_edge
 
 ; CHECK:  .split..split.split_crit_edge:                    ; preds = %.split
 ; CHECK:    br label %.split.split


### PR DESCRIPTION
(This patch contains https://github.com/snu-sf/llvm-freeze/pull/37)

Summary of this PR : 
- It freezes the branch condition in loop unswitch
- If the branch is guaranteed  to be executed (e.g. always reachable from loop pre-header), don't freeze the condition
- Modify several llvm loop-unswitch tests so `make check-llvm` says all tests pass.

Update from previous PR (https://github.com/snu-sf/llvm-freeze/pull/36) : 

- https://github.com/snu-sf/llvm-freeze/pull/36/commits/5934c5d01d18b00fb1c86e8446edace8c4204ae8 is splitted into two distinct commits ((1) implement freeze, (2) no freeze in certain condition)
- I added a new test case (`freeze.ll`) which includes 4 cases which must introduce freeze, and 2 cases which must not introduce freeze.

I'll run SPEC and LNT with this PR, and check they compile correctly.